### PR TITLE
chore: add project.urls to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
     "docker>=7.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/SchweizerischeBundesbahnen/python-sbb-polarion"
+Repository = "https://github.com/SchweizerischeBundesbahnen/python-sbb-polarion"
+
 [project.scripts]
 python-sbb-polarion-lint = "python_sbb_polarion.linter:main"
 

--- a/uv.lock
+++ b/uv.lock
@@ -896,7 +896,7 @@ wheels = [
 
 [[package]]
 name = "python-sbb-polarion"
-version = "0.0.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## Summary
- Add `[project.urls]` section with Homepage and Repository URLs to `pyproject.toml`
- Aligns metadata with [open-source-polarion-python-repo-template](https://github.com/SchweizerischeBundesbahnen/open-source-polarion-python-repo-template)

Closes #26

## Test plan
- [x] Pre-commit hooks pass (toml validation, uv-lock check)
- [ ] CI passes