### PR TITLE
chore: remove __version__ from __init__.py

### DIFF
--- a/python_sbb_polarion/__init__.py
+++ b/python_sbb_polarion/__init__.py
@@ -22,9 +22,6 @@ from python_sbb_polarion.core import (
 )
 
 
-# Version will be set by CI/CD
-__version__ = "2.0.2"
-
 # Add NullHandler to prevent "No handlers could be found" warning
 # if the application doesn't configure logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())  # noqa: RUF067 - stdlib NullHandler convention for libraries

--- a/uv.lock
+++ b/uv.lock
@@ -896,7 +896,7 @@ wheels = [
 
 [[package]]
 name = "python-sbb-polarion"
-version = "2.0.0"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## Summary
- Remove `__version__` from `python_sbb_polarion/__init__.py` — version is already in `pyproject.toml` (single source of truth), nothing imports it
- Sync `uv.lock` version with `pyproject.toml` (2.0.2)

Closes #40

## Test plan
- [x] `grep -r __version__` shows no remaining references
- [ ] CI passes