### PR TITLE
feat!: add new endpoints for LLMs and document operations in Polarion 2606

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 | Class | Description | Status |
 |-------|-------------|--------|
-| `PolarionApiV1` | Full Polarion REST API v1 (based on Polarion 2512) | **CURRENT** - use this |
+| `PolarionApiV1` | Full Polarion REST API v1 (based on Polarion 2606) | **CURRENT** - use this |
 
 **Notes:**
 - `PolarionApiV1` provides complete coverage of Polarion REST API v1 endpoints
-- OpenAPI spec source: Polarion 2512
+- OpenAPI spec source: Polarion 2606
 
 **Error Handling Philosophy:**
 - Response-based approach - API methods ALWAYS return `Response` (never `None`)
@@ -785,7 +785,7 @@ Reusable utilities shared across all modules:
 ### Core Module (`python_sbb_polarion/core/`)
 Core Polarion API components:
 - `base.py` - Base classes: `PolarionGenericExtensionApi`, `PolarionGenericExtensionSettingsApi` (mixin), and `PolarionRestApiConnection`
-- `polarion_api/` - `PolarionApiV1` - Full Polarion REST API v1 (based on Polarion 2512 OpenAPI spec)
+- `polarion_api/` - `PolarionApiV1` - Full Polarion REST API v1 (based on Polarion 2606 OpenAPI spec)
 - `factory.py` - `ExtensionApiFactory` - Factory for creating extension API instances
 - `annotations.py` - `@restapi_endpoint` decorator for explicit OpenAPI endpoint mapping
 
@@ -964,4 +964,4 @@ Artifacts archived: `dist/*`, `.coverage`, `coverage.xml`, `junittest.xml`
 
 | Library Version | Polarion Version | OpenAPI Spec |
 |-----------------|------------------|--------------|
-| Current | 2512 | `PolarionApiV1` based on 2512 |
+| Current | 2606 | `PolarionApiV1` based on 2606 |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ connection = PolarionRestApiConnection(
     token="your-api-token"
 )
 
-# Use Polarion REST API v1 (based on Polarion 2512 OpenAPI spec)
+# Use Polarion REST API v1 (based on Polarion 2606 OpenAPI spec)
 api = PolarionApiV1(connection)
 workitem = api.get_workitem("PROJECT", "ITEM-123")
 
@@ -52,9 +52,9 @@ result = pdf_api.convert({"projectId": "PROJECT", "documentName": "doc"})
 
 | Class | Description | Status |
 |-------|-------------|--------|
-| `PolarionApiV1` | Full Polarion REST API v1 (based on Polarion 2512) | **Current** - use this |
+| `PolarionApiV1` | Full Polarion REST API v1 (based on Polarion 2606) | **Current** - use this |
 
-**Current version:** Polarion 2512
+**Current version:** Polarion 2606
 
 ## Documentation
 
@@ -68,7 +68,7 @@ result = pdf_api.convert({"projectId": "PROJECT", "documentName": "doc"})
 python_sbb_polarion/
 ├── util/           # Shared utilities (HTTP, SSH, LDAP, SQL, OAuth, mailer, etc.)
 ├── core/           # Core Polarion API (base classes, main API, factory)
-│   └── polarion_api/       # PolarionApiV1 (current, based on Polarion 2512)
+│   └── polarion_api/       # PolarionApiV1 (current, based on Polarion 2606)
 │       ├── _documents/     # Document operations
 │       ├── _global/        # Global operations (users, enumerations)
 │       ├── _plans/         # Plan operations

--- a/polarion-openapi.json
+++ b/polarion-openapi.json
@@ -2,7 +2,7 @@
   "openapi" : "3.0.1",
   "info" : {
     "title" : "Polarion REST API",
-    "description" : "<h5>About</h5>The Polarion REST API lets you interact with Polarion programmatically. Use this API to integrate Polarion with your applications. This page documents the REST resources, including the HTTP response codes and example requests and responses. <br/><br/>For a detailed description of the REST API and how to use it, see the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> (available on Support Center).",
+    "description" : "<h5>About</h5>The Polarion REST API lets you interact with Polarion programmatically. Use this API to integrate Polarion with your applications. This page documents the REST resources, including the HTTP response codes and example requests and responses. <br/><br/>For a detailed description of the REST API and how to use it, see the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> (available on Support Center).",
     "contact" : {
       "name" : "Polarion REST API Support",
       "url" : "https://support.sw.siemens.com/"
@@ -45,7 +45,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -53,7 +53,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -61,7 +61,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -69,7 +69,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -113,7 +113,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -199,7 +209,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -265,7 +285,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -302,7 +332,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -310,7 +340,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -354,7 +384,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -412,7 +452,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -487,7 +537,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -516,7 +576,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -524,7 +584,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -532,7 +592,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -540,7 +600,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -598,7 +658,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -675,7 +745,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -742,7 +822,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -787,7 +877,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -795,7 +885,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -803,7 +893,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -811,7 +901,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -855,7 +945,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -941,7 +1041,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1027,7 +1137,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1110,7 +1230,94 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/collections/{collectionId}/actions/getFieldsMetadata" : {
+      "get" : {
+        "tags" : [ "Collections" ],
+        "summary" : "Returns fields for the specified resource.",
+        "operationId" : "getFieldsMetadataForCollection",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "collectionId",
+          "in" : "path",
+          "description" : "The Collection ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/fieldsMetadataActionResponseBody"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1176,7 +1383,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1270,7 +1487,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1299,7 +1526,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -1337,7 +1564,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1358,7 +1595,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -1366,7 +1603,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -1374,7 +1611,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -1412,7 +1649,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1465,7 +1712,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -1473,7 +1720,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -1517,7 +1764,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1532,7 +1789,7 @@
       "patch" : {
         "tags" : [ "Document Attachments" ],
         "summary" : "Updates the specified Document Attachment.",
-        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "patchDocumentAttachment",
         "parameters" : [ {
           "name" : "projectId",
@@ -1608,7 +1865,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1694,7 +1961,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1739,7 +2016,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -1747,7 +2024,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -1755,7 +2032,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -1763,7 +2040,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -1807,7 +2084,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1822,7 +2109,7 @@
       "post" : {
         "tags" : [ "Document Attachments" ],
         "summary" : "Creates a list of Document Attachments.",
-        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "postDocumentItemAttachments",
         "parameters" : [ {
           "name" : "projectId",
@@ -1901,7 +2188,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -1954,7 +2251,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -1962,7 +2259,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -2006,7 +2303,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2097,7 +2404,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2142,7 +2459,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -2150,7 +2467,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -2158,7 +2475,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -2166,7 +2483,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -2210,7 +2527,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2303,7 +2630,7 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2312,103 +2639,8 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/projects/{projectId}/spaces/{spaceId}/documents/{documentName}/parts/{partId}" : {
-      "get" : {
-        "tags" : [ "Document Parts" ],
-        "summary" : "Returns the specified Document Part.",
-        "operationId" : "getDocumentPart",
-        "parameters" : [ {
-          "name" : "projectId",
-          "in" : "path",
-          "description" : "The Project ID.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "spaceId",
-          "in" : "path",
-          "description" : "The Space ID. (Use '_default' without quotes to address the default Space.)",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "documentName",
-          "in" : "path",
-          "description" : "The Document name.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "partId",
-          "in" : "path",
-          "description" : "The Document Part ID.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "fields",
-          "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
-          "style" : "deepObject",
-          "schema" : {
-            "$ref" : "#/components/schemas/sparseFields"
-          }
-        }, {
-          "name" : "include",
-          "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "revision",
-          "in" : "query",
-          "description" : "The revision ID.",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/document_partsSingleGetResponse"
-                }
-              }
-            }
           },
-          "400" : {
-            "description" : "Bad Request"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "406" : {
-            "description" : "Not Acceptable"
-          },
-          "500" : {
-            "description" : "Internal Server Error"
-          },
-          "503" : {
-            "description" : "Service Unavailable"
-          },
-          "4XX-5XX" : {
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2453,7 +2685,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -2461,7 +2693,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -2469,7 +2701,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -2477,7 +2709,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -2521,7 +2753,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2614,7 +2856,225 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "Document Parts" ],
+        "summary" : "Deletes a list of Document Parts.",
+        "operationId" : "deleteDocumentParts",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "spaceId",
+          "in" : "path",
+          "description" : "The Space ID. (Use '_default' without quotes to address the default Space.)",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "documentName",
+          "in" : "path",
+          "description" : "The Document name.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The list of Document Part IDs to delete.",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/document_partsListDeleteRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "409" : {
+            "description" : "Conflict"
+          },
+          "413" : {
+            "description" : "Request Entity Too Large"
+          },
+          "415" : {
+            "description" : "Unsupported Media Type"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/spaces/{spaceId}/documents/{documentName}/parts/{partId}" : {
+      "get" : {
+        "tags" : [ "Document Parts" ],
+        "summary" : "Returns the specified Document Part.",
+        "operationId" : "getDocumentPart",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "spaceId",
+          "in" : "path",
+          "description" : "The Space ID. (Use '_default' without quotes to address the default Space.)",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "documentName",
+          "in" : "path",
+          "description" : "The Document name.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "partId",
+          "in" : "path",
+          "description" : "The Document Part ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "fields",
+          "in" : "query",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "style" : "deepObject",
+          "schema" : {
+            "$ref" : "#/components/schemas/sparseFields"
+          }
+        }, {
+          "name" : "include",
+          "in" : "query",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "revision",
+          "in" : "query",
+          "description" : "The revision ID.",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/document_partsSingleGetResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2707,7 +3167,122 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/spaces/{spaceId}/documents/{documentName}/parts/actions/overwrite" : {
+      "post" : {
+        "tags" : [ "Document Parts" ],
+        "summary" : "Overwrites multiple Work Item Document Parts.",
+        "operationId" : "overwriteDocumentParts",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "spaceId",
+          "in" : "path",
+          "description" : "The Space ID. (Use '_default' without quotes to address the default Space.)",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "documentName",
+          "in" : "path",
+          "description" : "The Document name.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "Parameters for overwriting multiple Work Item Document Parts.",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/overwriteDocumentPartsRequestBody"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/overwriteDocumentPartsResponseBody"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "409" : {
+            "description" : "Conflict"
+          },
+          "413" : {
+            "description" : "Request Entity Too Large"
+          },
+          "415" : {
+            "description" : "Unsupported Media Type"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2809,7 +3384,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2911,7 +3496,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -2964,7 +3559,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -2972,7 +3567,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -3010,7 +3605,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3063,7 +3668,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -3071,7 +3676,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -3116,7 +3721,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3161,7 +3776,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -3169,7 +3784,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -3213,7 +3828,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3303,7 +3928,102 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/spaces/{spaceId}/documents/{documentName}/actions/getFieldsMetadata" : {
+      "get" : {
+        "tags" : [ "Documents" ],
+        "summary" : "Returns fields for the specified resource.",
+        "operationId" : "getFieldsMetadataForDocument",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "spaceId",
+          "in" : "path",
+          "description" : "The Space ID. (Use '_default' without quotes to address the default Space.)",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "documentName",
+          "in" : "path",
+          "description" : "The Branch Document Name.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/fieldsMetadataActionResponseBody"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3340,7 +4060,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -3348,7 +4068,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -3356,7 +4076,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -3364,7 +4084,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -3415,7 +4135,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3500,7 +4230,114 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/spaces/{spaceId}/documents/actions/importWordDocument" : {
+      "post" : {
+        "tags" : [ "Documents" ],
+        "summary" : "Imports a Word document to create a new Polarion Document.",
+        "operationId" : "importWordDocument",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "spaceId",
+          "in" : "path",
+          "description" : "The Space ID. (Use '_default' without quotes to address the default Space.)",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "Multipart form data with 'file' (binary .docx) and 'parameters' (JSON object with documentName, title, documentType, and optional configurationId).",
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/importWordDocumentRequestBody"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "202" : {
+            "description" : "Accepted",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/jobsSinglePostResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "409" : {
+            "description" : "Conflict"
+          },
+          "413" : {
+            "description" : "Request Entity Too Large"
+          },
+          "415" : {
+            "description" : "Unsupported Media Type"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3594,7 +4431,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3688,7 +4535,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3725,7 +4582,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -3733,7 +4590,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -3778,7 +4635,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3848,7 +4715,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -3856,7 +4723,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -3900,7 +4767,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -3990,7 +4867,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4028,7 +4915,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -4036,7 +4923,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -4044,7 +4931,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -4052,7 +4939,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -4096,7 +4983,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4181,7 +5078,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4256,7 +5163,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4317,7 +5234,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -4325,7 +5242,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -4369,7 +5286,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4406,7 +5333,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -4414,7 +5341,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -4422,7 +5349,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -4430,7 +5357,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -4474,7 +5401,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4491,7 +5428,6 @@
       "get" : {
         "tags" : [ "Metadata" ],
         "summary" : "Returns fields for the resource type and its target type in the Project context.",
-        "description" : "Metadata support is limited to the following resource types: **Work Items**, **Documents**, **Test Runs**, and **Plans**.",
         "operationId" : "getProjectFieldsMetadata",
         "parameters" : [ {
           "name" : "projectId",
@@ -4504,7 +5440,7 @@
         }, {
           "name" : "resourceType",
           "in" : "query",
-          "description" : "The Resource Type. Accepted values: workitems, documents, testruns and plans.",
+          "description" : "The Resource Type.",
           "required" : true,
           "schema" : {
             "type" : "string"
@@ -4549,7 +5485,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4586,7 +5532,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -4594,7 +5540,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -4631,7 +5577,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4689,7 +5645,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4764,7 +5730,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4834,7 +5810,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4895,7 +5881,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -4916,7 +5912,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -4924,7 +5920,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -4932,7 +5928,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -4940,7 +5936,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -4998,7 +5994,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5043,7 +6049,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -5051,7 +6057,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -5088,7 +6094,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5154,7 +6170,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5237,7 +6263,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5258,7 +6294,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5266,7 +6302,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5274,7 +6310,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -5312,7 +6348,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5380,7 +6426,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5397,12 +6453,11 @@
       "get" : {
         "tags" : [ "Metadata" ],
         "summary" : "Returns fields for the resource type and its target type in the Global context.",
-        "description" : "Metadata support is limited to the following resource types: **Work Items**, **Documents**, **Test Runs**, and **Plans**.",
         "operationId" : "getGlobalFieldsMetadata",
         "parameters" : [ {
           "name" : "resourceType",
           "in" : "query",
-          "description" : "The Resource Type. Accepted values: workitems, documents, testruns and plans.",
+          "description" : "The Resource Type.",
           "required" : true,
           "schema" : {
             "type" : "string"
@@ -5447,7 +6502,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5476,7 +6541,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -5514,7 +6579,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5535,7 +6610,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5543,7 +6618,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5551,7 +6626,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -5589,7 +6664,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5658,7 +6743,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5679,7 +6774,7 @@
         "parameters" : [ {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -5687,7 +6782,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -5724,7 +6819,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5745,7 +6850,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5753,7 +6858,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5761,7 +6866,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -5769,7 +6874,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -5827,7 +6932,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5848,7 +6963,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5856,7 +6971,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5864,7 +6979,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -5872,7 +6987,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -5923,7 +7038,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -5952,7 +7077,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5960,7 +7085,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -5968,7 +7093,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -5976,7 +7101,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -6034,7 +7159,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6063,7 +7198,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -6071,7 +7206,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -6108,7 +7243,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6129,7 +7274,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -6137,7 +7282,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -6145,7 +7290,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -6153,7 +7298,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -6211,7 +7356,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6266,7 +7421,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6329,7 +7494,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6390,7 +7565,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6419,7 +7604,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -6427,7 +7612,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -6464,7 +7649,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6519,7 +7714,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6582,7 +7787,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6603,7 +7818,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -6611,7 +7826,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -6619,7 +7834,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -6627,7 +7842,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -6671,7 +7886,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6687,12 +7912,12 @@
     "/license/assignments" : {
       "get" : {
         "tags" : [ "License" ],
-        "summary" : "Returns a list of License Assignments.",
+        "summary" : "Returns a list of License Assignments. (Not supported by cloud-based Polarion X.)",
         "operationId" : "getLicenseAssignments",
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -6700,7 +7925,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -6708,7 +7933,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -6716,14 +7941,14 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
         }, {
           "name" : "activeOnly",
           "in" : "query",
-          "description" : "If set to true, only active (with status LOGGED_IN or EXPIRING) license assigments will be returned, otherwise all the license assignments will be returned.",
+          "description" : "If set to true, only active (with status LOGGED_IN or EXPIRING) License Assignments will be returned, otherwise all the License Assignments will be returned.",
           "schema" : {
             "type" : "boolean"
           }
@@ -6746,7 +7971,7 @@
             "description" : "Unauthorized"
           },
           "403" : {
-            "description" : "Forbidden"
+            "description" : "Forbidden (insufficient permissions or Polarion X environment)"
           },
           "404" : {
             "description" : "Not Found"
@@ -6760,7 +7985,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6774,10 +8009,10 @@
       },
       "patch" : {
         "tags" : [ "License" ],
-        "summary" : "Updates the License Assignments of multiple users.",
+        "summary" : "Updates the License Assignments of multiple users. (Not supported by cloud-based Polarion X.)",
         "operationId" : "patchLicenseAssignments",
         "requestBody" : {
-          "description" : "The User(s) license assignment body.",
+          "description" : "The User(s) License Assignment body.",
           "content" : {
             "application/json" : {
               "schema" : {
@@ -6789,7 +8024,7 @@
         },
         "responses" : {
           "200" : {
-            "description" : "The request was processed, but some user license assignments could not be changed because they are locked or because of license slot limits. See the errors array in the response for details about each failure."
+            "description" : "The request was processed, but some user License Assignments could not be changed because they are locked or because of license slot limits. See the errors array in the response for details about each failure."
           },
           "204" : {
             "description" : "No Content"
@@ -6801,7 +8036,7 @@
             "description" : "Unauthorized"
           },
           "403" : {
-            "description" : "Forbidden"
+            "description" : "Forbidden (insufficient permissions or Polarion X environment)"
           },
           "409" : {
             "description" : "Conflict"
@@ -6818,7 +8053,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6834,7 +8079,7 @@
     "/license/assignments/{userId}" : {
       "get" : {
         "tags" : [ "License" ],
-        "summary" : "Returns the specified License Assignment.",
+        "summary" : "Returns the specified License Assignment. (Not supported by cloud-based Polarion X.)",
         "operationId" : "getLicenseAssignmentsForUser",
         "parameters" : [ {
           "name" : "userId",
@@ -6846,7 +8091,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -6854,7 +8099,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -6877,7 +8122,7 @@
             "description" : "Unauthorized"
           },
           "403" : {
-            "description" : "Forbidden"
+            "description" : "Forbidden (insufficient permissions or Polarion X environment)"
           },
           "404" : {
             "description" : "Not Found"
@@ -6891,7 +8136,94 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch" : {
+        "tags" : [ "License" ],
+        "summary" : "Updates a user's License Assignment. (Not supported by cloud-based Polarion X.)",
+        "operationId" : "patchLicenseAssignment",
+        "parameters" : [ {
+          "name" : "userId",
+          "in" : "path",
+          "description" : "The User ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The User License Assignment body.",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/license_assignmentsSinglePatchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden (insufficient permissions or Polarion X environment)"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "409" : {
+            "description" : "Conflict"
+          },
+          "413" : {
+            "description" : "Request Entity Too Large"
+          },
+          "415" : {
+            "description" : "Unsupported Media Type"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6912,7 +8244,7 @@
         "parameters" : [ {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -6920,7 +8252,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -6957,7 +8289,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -6971,7 +8313,7 @@
       },
       "patch" : {
         "tags" : [ "License" ],
-        "summary" : "Updates the product License.",
+        "summary" : "Updates the product License. (Not supported by cloud-based Polarion X.)",
         "operationId" : "patchLicense",
         "requestBody" : {
           "description" : "The License body.",
@@ -6995,7 +8337,7 @@
             "description" : "Unauthorized"
           },
           "403" : {
-            "description" : "Forbidden"
+            "description" : "Forbidden (insufficient permissions or Polarion X environment)"
           },
           "404" : {
             "description" : "Not Found"
@@ -7015,7 +8357,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7031,7 +8383,7 @@
     "/license/types/{typeId}/slots" : {
       "get" : {
         "tags" : [ "License" ],
-        "summary" : "Returns information on the available License Slots.",
+        "summary" : "Returns information on the available License Slots. (Not supported by cloud-based Polarion X.)",
         "operationId" : "getLicenseSlots",
         "parameters" : [ {
           "name" : "typeId",
@@ -7043,7 +8395,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -7051,7 +8403,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -7059,7 +8411,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -7067,7 +8419,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -7097,7 +8449,7 @@
             "description" : "Unauthorized"
           },
           "403" : {
-            "description" : "Forbidden"
+            "description" : "Forbidden (insufficient permissions or Polarion X environment)"
           },
           "404" : {
             "description" : "Not Found"
@@ -7111,7 +8463,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7125,7 +8487,7 @@
       },
       "post" : {
         "tags" : [ "License" ],
-        "summary" : "Creates a list of group License Slots.",
+        "summary" : "Creates a list of group License Slots. (Not supported by cloud-based Polarion X.)",
         "operationId" : "postLicenseSlots",
         "parameters" : [ {
           "name" : "typeId",
@@ -7164,7 +8526,7 @@
             "description" : "Unauthorized"
           },
           "403" : {
-            "description" : "Forbidden"
+            "description" : "Forbidden (insufficient permissions or Polarion X environment)"
           },
           "404" : {
             "description" : "Not Found"
@@ -7187,7 +8549,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7201,7 +8573,7 @@
       },
       "delete" : {
         "tags" : [ "License" ],
-        "summary" : "Deletes a list of Group license slots.",
+        "summary" : "Deletes a list of Group license slots. (Not supported by cloud-based Polarion X.)",
         "operationId" : "deleteLicenseSlots",
         "parameters" : [ {
           "name" : "typeId",
@@ -7234,7 +8606,7 @@
             "description" : "Unauthorized"
           },
           "403" : {
-            "description" : "Forbidden"
+            "description" : "Forbidden (insufficient permissions or Polarion X environment)"
           },
           "404" : {
             "description" : "Not Found"
@@ -7254,7 +8626,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7270,7 +8652,7 @@
     "/license/types/{typeId}/slots/{model}/{group}" : {
       "get" : {
         "tags" : [ "License" ],
-        "summary" : "Returns the specified License Slot.",
+        "summary" : "Returns the specified License Slot. (Not supported by cloud-based Polarion X.)",
         "operationId" : "getLicenseSlot",
         "parameters" : [ {
           "name" : "typeId",
@@ -7296,7 +8678,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -7304,7 +8686,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -7327,7 +8709,7 @@
             "description" : "Unauthorized"
           },
           "403" : {
-            "description" : "Forbidden"
+            "description" : "Forbidden (insufficient permissions or Polarion X environment)"
           },
           "404" : {
             "description" : "Not Found"
@@ -7341,7 +8723,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7378,7 +8770,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -7386,7 +8778,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -7394,7 +8786,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -7402,7 +8794,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -7460,7 +8852,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7545,7 +8947,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7620,7 +9032,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7682,7 +9104,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -7690,7 +9112,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -7734,7 +9156,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7817,7 +9249,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7917,7 +9359,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -7955,7 +9407,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -7963,7 +9415,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -7971,7 +9423,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -7979,7 +9431,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -8023,7 +9475,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8109,7 +9571,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8185,7 +9657,174 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/llms/actions/generateCompletion" : {
+      "post" : {
+        "tags" : [ "AI" ],
+        "summary" : "Generates a chat completion using a Large Language Model (LLM).",
+        "operationId" : "generateCompletion",
+        "requestBody" : {
+          "description" : "Generate completion parameters.",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/generateCompletionRequestBody"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/generateCompletionResponseBody"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "409" : {
+            "description" : "Conflict"
+          },
+          "413" : {
+            "description" : "Request Entity Too Large"
+          },
+          "415" : {
+            "description" : "Unsupported Media Type"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/llms" : {
+      "get" : {
+        "tags" : [ "AI" ],
+        "summary" : "Returns a list of Large Language Models (LLMs).",
+        "operationId" : "getLlms",
+        "parameters" : [ {
+          "name" : "page[size]",
+          "in" : "query",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "page[number]",
+          "in" : "query",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/llmsListGetResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8222,7 +9861,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -8230,7 +9869,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -8274,7 +9913,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8332,7 +9981,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8407,7 +10066,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8452,7 +10121,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -8460,7 +10129,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -8468,7 +10137,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -8476,7 +10145,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -8520,7 +10189,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8606,7 +10285,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8692,7 +10381,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8775,7 +10474,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8804,7 +10513,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -8812,7 +10521,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -8820,7 +10529,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -8828,7 +10537,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -8893,7 +10602,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -8970,7 +10689,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9037,7 +10766,94 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/plans/{planId}/actions/getFieldsMetadata" : {
+      "get" : {
+        "tags" : [ "Plans" ],
+        "summary" : "Returns fields for the specified resource.",
+        "operationId" : "getFieldsMetadataForPlan",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "planId",
+          "in" : "path",
+          "description" : "The Plan ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/fieldsMetadataActionResponseBody"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9082,7 +10898,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -9090,7 +10906,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -9127,7 +10943,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9193,7 +11019,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9276,7 +11112,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9355,7 +11201,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9384,7 +11240,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -9392,7 +11248,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -9400,7 +11256,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -9408,7 +11264,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -9466,7 +11322,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9519,7 +11385,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -9527,7 +11393,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -9564,7 +11430,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9638,7 +11514,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9729,7 +11615,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9758,7 +11654,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -9766,7 +11662,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -9774,7 +11670,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -9812,7 +11708,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9889,7 +11795,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9926,7 +11842,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -9964,7 +11880,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -9993,7 +11919,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -10001,7 +11927,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -10009,7 +11935,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -10047,7 +11973,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10124,7 +12060,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10169,7 +12115,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -10177,7 +12123,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -10221,7 +12167,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10287,7 +12243,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10370,7 +12336,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10423,7 +12399,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -10431,7 +12407,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -10439,7 +12415,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -10447,7 +12423,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -10491,7 +12467,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10585,7 +12571,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10679,7 +12675,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10770,7 +12776,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10799,7 +12815,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -10807,7 +12823,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -10815,7 +12831,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -10823,7 +12839,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -10881,7 +12897,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -10918,7 +12944,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -10926,7 +12952,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -10934,7 +12960,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -10942,7 +12968,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -10993,7 +13019,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11078,7 +13114,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11099,7 +13145,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -11107,7 +13153,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -11115,7 +13161,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -11123,7 +13169,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -11160,7 +13206,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11221,7 +13277,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11250,7 +13316,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -11258,7 +13324,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -11302,7 +13368,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11347,7 +13423,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11414,7 +13500,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11451,7 +13547,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -11459,7 +13555,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -11496,7 +13592,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11554,7 +13660,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11583,7 +13699,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -11591,7 +13707,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -11599,7 +13715,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -11607,7 +13723,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -11644,7 +13760,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11721,7 +13847,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11788,7 +13924,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11809,7 +13955,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -11817,7 +13963,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -11825,7 +13971,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -11833,7 +13979,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -11891,7 +14037,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -11952,7 +14108,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12022,7 +14188,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12072,7 +14248,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12109,7 +14295,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -12117,7 +14303,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -12154,7 +14340,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12175,7 +14371,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -12183,7 +14379,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -12191,7 +14387,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -12199,7 +14395,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -12250,7 +14446,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12303,7 +14509,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -12311,7 +14517,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -12355,7 +14561,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12429,7 +14645,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12444,7 +14670,7 @@
       "patch" : {
         "tags" : [ "Page Attachments" ],
         "summary" : "Updates the specified Page Attachment.",
-        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "patchPageAttachment",
         "parameters" : [ {
           "name" : "projectId",
@@ -12520,7 +14746,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12606,7 +14842,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12651,7 +14897,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -12659,7 +14905,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -12667,7 +14913,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -12675,7 +14921,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -12719,7 +14965,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12734,7 +14990,7 @@
       "post" : {
         "tags" : [ "Page Attachments" ],
         "summary" : "Creates a list of Page Attachments.",
-        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "postPageAttachments",
         "parameters" : [ {
           "name" : "projectId",
@@ -12810,7 +15066,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -12863,7 +15129,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -12871,7 +15137,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -12915,7 +15181,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13006,7 +15282,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13051,7 +15337,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -13059,7 +15345,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -13067,7 +15353,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -13075,7 +15361,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -13119,7 +15405,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13212,7 +15508,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13281,7 +15587,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -13289,7 +15595,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -13333,7 +15639,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13423,7 +15739,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13438,7 +15764,7 @@
       "patch" : {
         "tags" : [ "Test Record Attachments" ],
         "summary" : "Updates the specified Test Record Attachment.",
-        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "patchTestRecordAttachment",
         "parameters" : [ {
           "name" : "projectId",
@@ -13530,7 +15856,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13591,7 +15927,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -13599,7 +15935,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -13607,7 +15943,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -13615,7 +15951,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -13659,7 +15995,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13674,7 +16020,7 @@
       "post" : {
         "tags" : [ "Test Record Attachments" ],
         "summary" : "Creates a list of Test Record Attachments.",
-        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "postTestRecordAttachments",
         "parameters" : [ {
           "name" : "projectId",
@@ -13769,7 +16115,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13868,7 +16224,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -13970,7 +16336,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14031,7 +16407,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -14039,7 +16415,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -14083,7 +16459,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14165,7 +16551,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14264,7 +16660,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14333,7 +16739,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -14341,7 +16747,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -14385,7 +16791,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14475,7 +16891,118 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/testruns/{testRunId}/testrecords/{testCaseProjectId}/{testCaseId}/{iteration}/actions/getFieldsMetadata" : {
+      "get" : {
+        "tags" : [ "Test Records" ],
+        "summary" : "Returns fields for the specified resource.",
+        "operationId" : "getFieldsMetadataForTestRecord",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "testRunId",
+          "in" : "path",
+          "description" : "The Test Run ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "testCaseProjectId",
+          "in" : "path",
+          "description" : "The Testcase Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "testCaseId",
+          "in" : "path",
+          "description" : "The Testcase ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "iteration",
+          "in" : "path",
+          "description" : "The Iteration Number.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/fieldsMetadataActionResponseBody"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14536,7 +17063,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -14544,7 +17071,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -14552,7 +17079,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -14560,7 +17087,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -14604,7 +17131,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14713,7 +17250,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14750,7 +17297,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -14758,7 +17305,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -14766,7 +17313,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -14774,7 +17321,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -14839,7 +17386,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14924,7 +17481,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -14999,7 +17566,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15044,7 +17621,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -15052,7 +17629,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -15096,7 +17673,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15162,7 +17749,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15177,7 +17774,7 @@
       "patch" : {
         "tags" : [ "Test Run Attachments" ],
         "summary" : "Updates the specified Test Run Attachment.",
-        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "patchTestRunAttachment",
         "parameters" : [ {
           "name" : "projectId",
@@ -15242,7 +17839,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15277,7 +17884,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -15285,7 +17892,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -15293,7 +17900,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -15301,7 +17908,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -15345,7 +17952,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15360,7 +17977,7 @@
       "post" : {
         "tags" : [ "Test Run Attachments" ],
         "summary" : "Creates a list of Test Run Attachments.",
-        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "postTestRunAttachments",
         "parameters" : [ {
           "name" : "projectId",
@@ -15429,7 +18046,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15504,7 +18131,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15582,7 +18219,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15627,7 +18274,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -15635,7 +18282,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -15679,7 +18326,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15762,7 +18419,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15799,7 +18466,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -15807,7 +18474,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -15815,7 +18482,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -15823,7 +18490,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -15867,7 +18534,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -15952,7 +18629,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16027,7 +18714,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16064,7 +18761,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -16072,7 +18769,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -16116,7 +18813,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16174,7 +18881,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16249,7 +18966,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16294,7 +19021,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -16302,7 +19029,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -16346,7 +19073,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16412,7 +19149,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16457,7 +19204,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -16465,7 +19212,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -16509,7 +19256,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16575,7 +19332,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16612,7 +19379,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -16620,7 +19387,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -16628,7 +19395,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -16636,7 +19403,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -16680,7 +19447,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16765,7 +19542,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16840,7 +19627,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -16869,7 +19666,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -16877,7 +19674,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -16885,7 +19682,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -16893,7 +19690,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -16958,7 +19755,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17035,7 +19842,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17102,7 +19919,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17169,7 +19996,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17263,7 +20100,94 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/testruns/{testRunId}/actions/getFieldsMetadata" : {
+      "get" : {
+        "tags" : [ "Test Runs" ],
+        "summary" : "Returns fields for the specified resource.",
+        "operationId" : "getFieldsMetadataForTestRun",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "testRunId",
+          "in" : "path",
+          "description" : "The Test Run ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/fieldsMetadataActionResponseBody"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17300,7 +20224,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -17308,7 +20232,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -17316,7 +20240,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -17324,7 +20248,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -17368,7 +20292,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17453,7 +20387,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17490,7 +20434,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -17498,7 +20442,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -17543,7 +20487,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17624,7 +20578,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17705,7 +20669,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17774,7 +20748,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -17782,7 +20756,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -17826,7 +20800,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17933,7 +20917,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -17994,7 +20988,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -18002,7 +20996,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -18010,7 +21004,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -18018,7 +21012,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -18062,7 +21056,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18171,7 +21175,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18270,7 +21284,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18315,7 +21339,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -18323,7 +21347,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -18367,7 +21391,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18433,7 +21467,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18516,7 +21560,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18553,7 +21607,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -18561,7 +21615,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -18569,7 +21623,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -18577,7 +21631,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -18621,7 +21675,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18706,7 +21770,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18781,7 +21855,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18856,7 +21940,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -18933,7 +22027,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -18941,7 +22035,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -18985,7 +22079,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19083,7 +22187,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19098,7 +22212,7 @@
       "patch" : {
         "tags" : [ "Test Step Result Attachments" ],
         "summary" : "Updates the specified Test Step Result Attachment.",
-        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "patchTestStepResultAttachment",
         "parameters" : [ {
           "name" : "projectId",
@@ -19198,7 +22312,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19267,7 +22391,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -19275,7 +22399,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -19283,7 +22407,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -19291,7 +22415,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -19335,7 +22459,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19350,7 +22484,7 @@
       "post" : {
         "tags" : [ "Test Step Result Attachments" ],
         "summary" : "Creates a list of Test Step Result Attachments.",
-        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "postTestStepResultAttachments",
         "parameters" : [ {
           "name" : "projectId",
@@ -19453,7 +22587,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19560,7 +22704,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19670,7 +22824,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19691,7 +22855,7 @@
         "parameters" : [ {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -19699,7 +22863,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -19743,7 +22907,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19772,7 +22946,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -19780,7 +22954,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -19824,7 +22998,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19879,7 +23063,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -19908,7 +23102,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -19916,7 +23110,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -19960,7 +23154,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20027,7 +23231,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20048,7 +23262,7 @@
         "parameters" : [ {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -20056,7 +23270,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -20064,7 +23278,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -20072,7 +23286,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -20130,7 +23344,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20198,7 +23422,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20267,7 +23501,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20335,7 +23579,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20380,7 +23634,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -20388,7 +23642,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -20432,7 +23686,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20498,7 +23762,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20581,7 +23855,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20618,7 +23902,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -20626,7 +23910,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -20634,7 +23918,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -20642,7 +23926,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -20686,7 +23970,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20771,7 +24065,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20846,7 +24150,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20921,7 +24235,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -20966,7 +24290,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -20974,7 +24298,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -21018,7 +24342,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21084,7 +24418,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21099,7 +24443,7 @@
       "patch" : {
         "tags" : [ "Work Item Attachments" ],
         "summary" : "Updates the specified Work Item Attachment.",
-        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "patchWorkItemAttachment",
         "parameters" : [ {
           "name" : "projectId",
@@ -21164,7 +24508,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21242,7 +24596,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21277,7 +24641,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -21285,7 +24649,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -21293,7 +24657,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -21301,7 +24665,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -21345,7 +24709,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21360,7 +24734,7 @@
       "post" : {
         "tags" : [ "Work Item Attachments" ],
         "summary" : "Creates a list of Work Item Attachments.",
-        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+        "description" : "Files are identified by order or optionally by the 'lid' attribute. See more in the <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
         "operationId" : "postWorkItemAttachments",
         "parameters" : [ {
           "name" : "projectId",
@@ -21429,7 +24803,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21474,7 +24858,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -21482,7 +24866,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -21526,7 +24910,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21609,7 +25003,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21646,7 +25050,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -21654,7 +25058,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -21662,7 +25066,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -21670,7 +25074,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -21714,7 +25118,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21799,7 +25213,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21828,7 +25252,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -21836,7 +25260,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -21844,7 +25268,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -21852,7 +25276,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -21910,7 +25334,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -21987,7 +25421,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22054,7 +25498,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22135,7 +25589,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22180,7 +25644,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -22188,7 +25652,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -22196,7 +25660,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -22204,7 +25668,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -22248,7 +25712,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22331,7 +25805,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22417,7 +25901,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22500,7 +25994,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22545,7 +26049,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -22553,7 +26057,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -22591,7 +26095,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22628,7 +26142,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -22636,7 +26150,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -22681,7 +26195,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22726,7 +26250,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -22734,7 +26258,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -22779,7 +26303,94 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/workitems/{workItemId}/actions/getFieldsMetadata" : {
+      "get" : {
+        "tags" : [ "Work Items" ],
+        "summary" : "Returns fields for the specified resource.",
+        "operationId" : "getFieldsMetadataForWorkItem",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "workItemId",
+          "in" : "path",
+          "description" : "The Work Item ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/fieldsMetadataActionResponseBody"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "406" : {
+            "description" : "Not Acceptable"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22816,7 +26427,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -22824,7 +26435,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -22868,7 +26479,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -22957,7 +26578,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23002,7 +26633,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -23010,7 +26641,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -23054,7 +26685,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23091,7 +26732,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -23099,7 +26740,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -23107,7 +26748,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -23115,7 +26756,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -23159,7 +26800,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23196,7 +26847,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -23204,7 +26855,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -23249,7 +26900,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23306,7 +26967,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23383,7 +27054,96 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/workitems/actions/moveToDocument" : {
+      "post" : {
+        "tags" : [ "Work Items" ],
+        "summary" : "Moves multiple Work Items to the Document.",
+        "operationId" : "moveWorkItemsToDocument",
+        "parameters" : [ {
+          "name" : "projectId",
+          "in" : "path",
+          "description" : "The Project ID.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "Moving Work Items to Document parameters.",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/moveWorkItemsToDocumentRequestBody"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "409" : {
+            "description" : "Conflict"
+          },
+          "413" : {
+            "description" : "Request Entity Too Large"
+          },
+          "415" : {
+            "description" : "Unsupported Media Type"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "503" : {
+            "description" : "Service Unavailable"
+          },
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23428,7 +27188,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -23436,7 +27196,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -23480,7 +27240,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23546,7 +27316,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23583,7 +27363,7 @@
         }, {
           "name" : "page[size]",
           "in" : "query",
-          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Limit the number of entities returned in a single response. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -23591,7 +27371,7 @@
         }, {
           "name" : "page[number]",
           "in" : "query",
-          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Specify the page number to be returned. Counting starts from 1. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "integer",
             "format" : "int32"
@@ -23599,7 +27379,7 @@
         }, {
           "name" : "fields",
           "in" : "query",
-          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Filter returned resource fields. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "style" : "deepObject",
           "schema" : {
             "$ref" : "#/components/schemas/sparseFields"
@@ -23607,7 +27387,7 @@
         }, {
           "name" : "include",
           "in" : "query",
-          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
+          "description" : "Include related entities. See <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a> for details.",
           "schema" : {
             "type" : "string"
           }
@@ -23651,7 +27431,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23736,7 +27526,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -23811,7 +27611,17 @@
           "503" : {
             "description" : "Service Unavailable"
           },
-          "4XX-5XX" : {
+          "4XX" : {
+            "description" : "Error responses have the following structure:",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/errors"
+                }
+              }
+            }
+          },
+          "5XX" : {
             "description" : "Error responses have the following structure:",
             "content" : {
               "application/json" : {
@@ -24263,7 +28073,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -24727,7 +28537,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -25430,7 +29240,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -25762,7 +29572,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -26106,7 +29916,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -26803,7 +30613,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -26984,7 +30794,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -27253,7 +31063,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -27381,7 +31191,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -27664,7 +31474,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -27863,7 +31673,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -28121,7 +31931,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -28420,7 +32230,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -28781,7 +32591,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -29076,7 +32886,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -29271,7 +33081,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -29617,7 +33427,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -29909,7 +33719,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -30213,7 +34023,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -31329,7 +35139,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -32169,7 +35979,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -33255,7 +37065,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -33653,7 +37463,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -34511,7 +38321,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -34913,7 +38723,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -35688,7 +39498,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -35883,7 +39693,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -36236,7 +40046,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -36491,7 +40301,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -36829,7 +40639,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -37024,7 +40834,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -37264,6 +41074,32 @@
                         "limited" : {
                           "type" : "boolean",
                           "example" : true
+                        },
+                        "linkRules" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "fromTypes" : {
+                                "type" : "array",
+                                "example" : [ "requirement" ],
+                                "items" : {
+                                  "type" : "string"
+                                }
+                              },
+                              "toTypes" : {
+                                "type" : "array",
+                                "example" : [ "requirement" ],
+                                "items" : {
+                                  "type" : "string"
+                                }
+                              },
+                              "sameType" : {
+                                "type" : "boolean",
+                                "example" : false
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -37344,7 +41180,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -37464,6 +41300,32 @@
                           "limited" : {
                             "type" : "boolean",
                             "example" : true
+                          },
+                          "linkRules" : {
+                            "type" : "array",
+                            "items" : {
+                              "type" : "object",
+                              "properties" : {
+                                "fromTypes" : {
+                                  "type" : "array",
+                                  "example" : [ "requirement" ],
+                                  "items" : {
+                                    "type" : "string"
+                                  }
+                                },
+                                "toTypes" : {
+                                  "type" : "array",
+                                  "example" : [ "requirement" ],
+                                  "items" : {
+                                    "type" : "string"
+                                  }
+                                },
+                                "sameType" : {
+                                  "type" : "boolean",
+                                  "example" : false
+                                }
+                              }
+                            }
                           }
                         }
                       }
@@ -37545,7 +41407,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -37662,6 +41524,32 @@
                         "limited" : {
                           "type" : "boolean",
                           "example" : true
+                        },
+                        "linkRules" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "properties" : {
+                              "fromTypes" : {
+                                "type" : "array",
+                                "example" : [ "requirement" ],
+                                "items" : {
+                                  "type" : "string"
+                                }
+                              },
+                              "toTypes" : {
+                                "type" : "array",
+                                "example" : [ "requirement" ],
+                                "items" : {
+                                  "type" : "string"
+                                }
+                              },
+                              "sameType" : {
+                                "type" : "boolean",
+                                "example" : false
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -37793,6 +41681,32 @@
                           "limited" : {
                             "type" : "boolean",
                             "example" : true
+                          },
+                          "linkRules" : {
+                            "type" : "array",
+                            "items" : {
+                              "type" : "object",
+                              "properties" : {
+                                "fromTypes" : {
+                                  "type" : "array",
+                                  "example" : [ "requirement" ],
+                                  "items" : {
+                                    "type" : "string"
+                                  }
+                                },
+                                "toTypes" : {
+                                  "type" : "array",
+                                  "example" : [ "requirement" ],
+                                  "items" : {
+                                    "type" : "string"
+                                  }
+                                },
+                                "sameType" : {
+                                  "type" : "boolean",
+                                  "example" : false
+                                }
+                              }
+                            }
                           }
                         }
                       }
@@ -37913,7 +41827,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -38046,7 +41960,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -38310,7 +42224,10 @@
                   },
                   "downloads" : {
                     "type" : "array",
-                    "example" : [ "http://localhost/polarion/download/filename1", "http://localhost/polarion/download/filename2" ]
+                    "example" : [ "http://localhost/polarion/download/filename1", "http://localhost/polarion/download/filename2" ],
+                    "items" : {
+                      "type" : "string"
+                    }
                   }
                 }
               }
@@ -38318,7 +42235,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -38530,7 +42447,10 @@
                     },
                     "downloads" : {
                       "type" : "array",
-                      "example" : [ "http://localhost/polarion/download/filename1", "http://localhost/polarion/download/filename2" ]
+                      "example" : [ "http://localhost/polarion/download/filename1", "http://localhost/polarion/download/filename2" ],
+                      "items" : {
+                        "type" : "string"
+                      }
                     }
                   }
                 }
@@ -38539,7 +42459,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -38690,7 +42610,10 @@
                   },
                   "downloads" : {
                     "type" : "array",
-                    "example" : [ "http://localhost/polarion/download/filename1", "http://localhost/polarion/download/filename2" ]
+                    "example" : [ "http://localhost/polarion/download/filename1", "http://localhost/polarion/download/filename2" ],
+                    "items" : {
+                      "type" : "string"
+                    }
                   }
                 }
               }
@@ -38865,7 +42788,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -39060,7 +42983,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -39209,28 +43132,52 @@
                 "properties" : {
                   "content" : {
                     "type" : "string",
+                    "description" : "Editable only for normal and table document parts.",
                     "example" : "<div id=\"polarion_wiki macro name=module-workitem;params=id=workitem_MyWorkItemId\"></div>"
                   },
                   "external" : {
-                    "type" : "boolean"
+                    "type" : "boolean",
+                    "description" : "Whether the work item is external to the document. Applicable to: workitem parts."
+                  },
+                  "headingText" : {
+                    "type" : "string",
+                    "description" : "Applicable to: heading parts.",
+                    "example" : "Heading Title"
                   },
                   "id" : {
                     "type" : "string",
                     "example" : "workitem_MyWorkItemId"
                   },
+                  "landscape" : {
+                    "type" : "boolean",
+                    "description" : "Whether the page break switches to landscape orientation. Applicable to: pagebreak parts."
+                  },
                   "layout" : {
                     "type" : "integer",
+                    "description" : "Rendering layout index for the part. Applicable to: workitem parts.",
                     "format" : "int32",
                     "example" : 0
                   },
                   "level" : {
                     "type" : "integer",
+                    "description" : "Outline level/depth of the part in the document hierarchy. Applicable to: heading, workitem parts.",
                     "format" : "int32",
                     "example" : 0
                   },
+                  "sequence" : {
+                    "type" : "string",
+                    "description" : "Sequence identifier for table of figures entry. Applicable to: tof parts.",
+                    "example" : "Table"
+                  },
                   "type" : {
                     "type" : "string",
+                    "description" : "Possible values: heading, normal, pagebreak, table, toc, tof, wikiblock, workitem. Required for creation.",
                     "example" : "workitem"
+                  },
+                  "wikiText" : {
+                    "type" : "string",
+                    "description" : "Wiki markup content for the block. Applicable to: wikiblock parts.",
+                    "example" : "#documentPanel(true \"approved\")"
                   }
                 }
               },
@@ -39375,7 +43322,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -39425,28 +43372,52 @@
                   "properties" : {
                     "content" : {
                       "type" : "string",
+                      "description" : "Editable only for normal and table document parts.",
                       "example" : "<div id=\"polarion_wiki macro name=module-workitem;params=id=workitem_MyWorkItemId\"></div>"
                     },
                     "external" : {
-                      "type" : "boolean"
+                      "type" : "boolean",
+                      "description" : "Whether the work item is external to the document. Applicable to: workitem parts."
+                    },
+                    "headingText" : {
+                      "type" : "string",
+                      "description" : "Applicable to: heading parts.",
+                      "example" : "Heading Title"
                     },
                     "id" : {
                       "type" : "string",
                       "example" : "workitem_MyWorkItemId"
                     },
+                    "landscape" : {
+                      "type" : "boolean",
+                      "description" : "Whether the page break switches to landscape orientation. Applicable to: pagebreak parts."
+                    },
                     "layout" : {
                       "type" : "integer",
+                      "description" : "Rendering layout index for the part. Applicable to: workitem parts.",
                       "format" : "int32",
                       "example" : 0
                     },
                     "level" : {
                       "type" : "integer",
+                      "description" : "Outline level/depth of the part in the document hierarchy. Applicable to: heading, workitem parts.",
                       "format" : "int32",
                       "example" : 0
                     },
+                    "sequence" : {
+                      "type" : "string",
+                      "description" : "Sequence identifier for table of figures entry. Applicable to: tof parts.",
+                      "example" : "Table"
+                    },
                     "type" : {
                       "type" : "string",
+                      "description" : "Possible values: heading, normal, pagebreak, table, toc, tof, wikiblock, workitem. Required for creation.",
                       "example" : "workitem"
+                    },
+                    "wikiText" : {
+                      "type" : "string",
+                      "description" : "Wiki markup content for the block. Applicable to: wikiblock parts.",
+                      "example" : "#documentPanel(true \"approved\")"
                     }
                   }
                 },
@@ -39592,7 +43563,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -39639,19 +43610,46 @@
                 "attributes" : {
                   "type" : "object",
                   "properties" : {
+                    "content" : {
+                      "type" : "string",
+                      "description" : "Editable only for normal and table document parts.",
+                      "example" : "<div id=\"polarion_wiki macro name=module-workitem;params=id=workitem_MyWorkItemId\"></div>"
+                    },
+                    "headingText" : {
+                      "type" : "string",
+                      "description" : "Applicable to: heading parts.",
+                      "example" : "Heading Title"
+                    },
+                    "landscape" : {
+                      "type" : "boolean",
+                      "description" : "Whether the page break switches to landscape orientation. Applicable to: pagebreak parts."
+                    },
                     "layout" : {
                       "type" : "integer",
+                      "description" : "Rendering layout index for the part. Applicable to: workitem parts.",
                       "format" : "int32",
                       "example" : 0
                     },
                     "level" : {
                       "type" : "integer",
+                      "description" : "Outline level/depth of the part in the document hierarchy. Applicable to: heading, workitem parts.",
                       "format" : "int32",
                       "example" : 0
                     },
+                    "sequence" : {
+                      "type" : "string",
+                      "description" : "Sequence identifier for table of figures entry. Applicable to: tof parts.",
+                      "example" : "Table"
+                    },
                     "type" : {
                       "type" : "string",
+                      "description" : "Possible values: heading, normal, pagebreak, table, toc, tof, wikiblock, workitem. Required for creation.",
                       "example" : "workitem"
+                    },
+                    "wikiText" : {
+                      "type" : "string",
+                      "description" : "Wiki markup content for the block. Applicable to: wikiblock parts.",
+                      "example" : "#documentPanel(true \"approved\")"
                     }
                   }
                 },
@@ -39747,6 +43745,27 @@
                       "example" : "server-host-name/application-path/projects/MyProjectId/spaces/MySpaceId/documents/MyDocumentId/parts/workitem_MyWorkItemId?revision=1234"
                     }
                   }
+                }
+              }
+            }
+          }
+        }
+      },
+      "document_partsListDeleteRequest" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "document_parts" ]
+                },
+                "id" : {
+                  "type" : "string",
+                  "example" : "MyProjectId/MySpaceId/MyDocumentId/workitem_MyWorkItemId"
                 }
               }
             }
@@ -39976,7 +43995,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -40227,7 +44246,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -40545,7 +44564,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -40716,7 +44735,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -40841,7 +44860,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -40970,7 +44989,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -41203,7 +45222,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -41363,7 +45382,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -41658,7 +45677,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -41884,7 +45903,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -42412,7 +46431,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -42607,7 +46626,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -42981,7 +47000,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -43236,7 +47255,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -43478,7 +47497,7 @@
                     },
                     "uri" : {
                       "type" : "string",
-                      "example" : "Uri"
+                      "example" : "URI"
                     }
                   }
                 },
@@ -43547,7 +47566,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -43579,7 +47598,7 @@
                     },
                     "uri" : {
                       "type" : "string",
-                      "example" : "Uri"
+                      "example" : "URI"
                     }
                   }
                 }
@@ -43795,7 +47814,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -43985,7 +48004,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -44255,7 +48274,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -44408,7 +48427,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -44558,7 +48577,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -44704,7 +48723,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -45061,7 +49080,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -45226,7 +49245,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -45577,7 +49596,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -45772,7 +49791,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -46044,7 +50063,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -46197,7 +50216,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -46527,7 +50546,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -46719,7 +50738,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -46915,7 +50934,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -46985,6 +51004,68 @@
                               "type" : "string",
                               "example" : "LicenseType/ModelType/GroupId"
                             }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "license_assignmentsSinglePatchRequest" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "license_assignments" ]
+              },
+              "id" : {
+                "type" : "string",
+                "example" : "MyUserId"
+              },
+              "relationships" : {
+                "type" : "object",
+                "properties" : {
+                  "addOnSlots" : {
+                    "type" : "object",
+                    "properties" : {
+                      "data" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "type" : {
+                              "type" : "string",
+                              "enum" : [ "license_slots" ]
+                            },
+                            "id" : {
+                              "type" : "string",
+                              "example" : "LicenseType/ModelType/GroupId"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "baseSlot" : {
+                    "type" : "object",
+                    "properties" : {
+                      "data" : {
+                        "type" : "object",
+                        "properties" : {
+                          "type" : {
+                            "type" : "string",
+                            "enum" : [ "license_slots" ]
+                          },
+                          "id" : {
+                            "type" : "string",
+                            "example" : "LicenseType/ModelType/GroupId"
                           }
                         }
                       }
@@ -47125,7 +51206,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -47355,7 +51436,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -47620,7 +51701,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -47980,7 +52061,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -48279,7 +52360,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -48404,7 +52485,7 @@
                           }
                         }
                       },
-                      "workitems" : {
+                      "documentsAndPages" : {
                         "type" : "object",
                         "properties" : {
                           "limit" : {
@@ -48415,7 +52496,7 @@
                           }
                         }
                       },
-                      "documentsAndPages" : {
+                      "workitems" : {
                         "type" : "object",
                         "properties" : {
                           "limit" : {
@@ -48553,7 +52634,7 @@
           },
           "included" : {
             "type" : "array",
-            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20250606201928474.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
             "items" : {
               "type" : "object"
             }
@@ -48631,6 +52712,112 @@
           }
         }
       },
+      "llmsListGetResponse" : {
+        "type" : "object",
+        "properties" : {
+          "meta" : {
+            "type" : "object",
+            "properties" : {
+              "totalCount" : {
+                "type" : "integer",
+                "format" : "int32"
+              }
+            }
+          },
+          "data" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "llms" ]
+                },
+                "id" : {
+                  "type" : "string",
+                  "example" : "myLlm"
+                },
+                "attributes" : {
+                  "type" : "object",
+                  "properties" : {
+                    "name" : {
+                      "type" : "string",
+                      "example" : "myLlm"
+                    }
+                  }
+                },
+                "meta" : {
+                  "type" : "object",
+                  "properties" : {
+                    "errors" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "status" : {
+                            "type" : "string",
+                            "description" : "HTTP status code applicable to this problem.",
+                            "example" : "400"
+                          },
+                          "title" : {
+                            "type" : "string",
+                            "description" : "Short, human-readable summary of the problem.",
+                            "example" : "Bad Request"
+                          },
+                          "detail" : {
+                            "type" : "string",
+                            "description" : "Human-readable explanation specific to this occurrence of the problem.",
+                            "example" : "Unexpected token, BEGIN_ARRAY expected, but was : BEGIN_OBJECT (at $.data)"
+                          },
+                          "source" : {
+                            "type" : "object",
+                            "properties" : {
+                              "pointer" : {
+                                "type" : "string",
+                                "description" : "JSON Pointer to the associated entity in the request document.",
+                                "example" : "$.data"
+                              },
+                              "parameter" : {
+                                "type" : "string",
+                                "description" : "String indicating which URI query parameter caused the error.",
+                                "example" : "revision"
+                              },
+                              "resource" : {
+                                "type" : "object",
+                                "properties" : {
+                                  "id" : {
+                                    "type" : "string",
+                                    "example" : "MyProjectId/id"
+                                  },
+                                  "type" : {
+                                    "type" : "string",
+                                    "example" : "type"
+                                  }
+                                },
+                                "description" : "Resource causing the error."
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "links" : {
+                  "type" : "object"
+                }
+              }
+            }
+          },
+          "included" : {
+            "type" : "array",
+            "description" : "Related entities might be returned, see <a href=\"https://docs.sw.siemens.com/en-US/doc/230235217/PL20251205943446859.polarion_help_sc.xid2134849/xid2134871\" target=\"_blank\">REST API User Guide</a>.",
+            "items" : {
+              "type" : "object"
+            }
+          }
+        }
+      },
       "relationshipsListDeleteRequest" : {
         "type" : "object",
         "properties" : {
@@ -48641,11 +52828,11 @@
               "properties" : {
                 "type" : {
                   "type" : "string",
-                  "enum" : [ "collections", "categories", "documents", "document_attachments", "document_comments", "document_parts", "enumerations", "globalroles", "icons", "jobs", "linkedworkitems", "externallylinkedworkitems", "linkedoslcresources", "pages", "page_attachments", "page_comments", "plans", "projectroles", "projectgroups", "projects", "projecttemplates", "spaces", "testparameters", "testparameter_definitions", "testrecords", "teststep_results", "testruns", "testrun_attachments", "teststepresult_attachments", "testrun_comments", "usergroups", "users", "workitems", "workitem_attachments", "workitem_approvals", "workitem_comments", "featureselections", "teststeps", "workrecords", "revisions", "testrecord_attachments", "license_slots", "license_types", "license", "metadata", "license_assignments", "customfields" ]
+                  "enum" : [ "collections", "categories", "documents", "document_attachments", "document_comments", "document_parts", "enumerations", "globalroles", "icons", "jobs", "linkedworkitems", "externallylinkedworkitems", "linkedoslcresources", "llms", "pages", "page_attachments", "page_comments", "plans", "projectroles", "projectgroups", "projects", "projecttemplates", "spaces", "testparameters", "testparameter_definitions", "testrecords", "teststep_results", "testruns", "testrun_attachments", "teststepresult_attachments", "testrun_comments", "usergroups", "users", "workitems", "workitem_attachments", "workitem_approvals", "workitem_comments", "featureselections", "teststeps", "workrecords", "revisions", "testrecord_attachments", "license_slots", "license_types", "license", "metadata", "license_assignments", "customfields" ]
                 },
                 "id" : {
                   "type" : "string",
-                  "example" : "MyProjectId/MyResourceId"
+                  "example" : "MyResourceId"
                 }
               }
             }
@@ -48716,6 +52903,11 @@
             "example" : "@all"
           },
           "linkedoslcresources" : {
+            "type" : "string",
+            "description" : "Requested fields",
+            "example" : "@all"
+          },
+          "llms" : {
             "type" : "string",
             "description" : "Requested fields",
             "example" : "@all"
@@ -49120,13 +53312,13 @@
           "params" : {
             "type" : "object",
             "properties" : {
-              "param1" : {
-                "type" : "string",
-                "example" : "value1"
-              },
               "param2" : {
                 "type" : "string",
                 "example" : "value2"
+              },
+              "param1" : {
+                "type" : "string",
+                "example" : "value1"
               }
             },
             "description" : "Parameters of Job to be executed.",
@@ -49192,6 +53384,46 @@
           }
         }
       },
+      "moveWorkItemsToDocumentRequestBody" : {
+        "type" : "object",
+        "properties" : {
+          "targetDocument" : {
+            "type" : "string",
+            "example" : "MyProjectId/MySpaceId/MyDocumentId"
+          },
+          "workItemGroups" : {
+            "type" : "array",
+            "example" : [ {
+              "previousPart" : "MyProjectId/MySpaceId/MyDocumentId/workitem_MyWorkItemId",
+              "workItemIds" : [ "MyProjectId/WI-123", "MyProjectId/WI-124" ]
+            }, {
+              "nextPart" : "MyProjectId/MySpaceId/MyDocumentId/workitem_MyWorkItemId",
+              "workItemIds" : [ "MyProjectId/WI-125" ]
+            } ],
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "workItemIds" : {
+                  "type" : "array",
+                  "example" : [ "MyProjectId/WI-123", "MyProjectId/WI-124" ],
+                  "items" : {
+                    "type" : "string",
+                    "description" : "The Work Item's path in the following format: ProjectId/workItemId"
+                  }
+                },
+                "previousPart" : {
+                  "type" : "string",
+                  "example" : "MyProjectId/MySpaceId/MyDocumentId/workitem_MyWorkItemId"
+                },
+                "nextPart" : {
+                  "type" : "string",
+                  "example" : "MyProjectId/MySpaceId/MyDocumentId/workitem_MyWorkItemId"
+                }
+              }
+            }
+          }
+        }
+      },
       "moveDocumentPartRequestBody" : {
         "type" : "object",
         "properties" : {
@@ -49206,6 +53438,49 @@
           "parent" : {
             "type" : "string",
             "example" : "MyProjectId/MySpaceId/MyDocumentId/workitem_MyWorkItemId"
+          }
+        }
+      },
+      "overwriteDocumentPartsRequestBody" : {
+        "required" : [ "partIds" ],
+        "type" : "object",
+        "properties" : {
+          "partIds" : {
+            "type" : "array",
+            "description" : "The list of Document Part IDs to overwrite.",
+            "items" : {
+              "type" : "string",
+              "example" : "MyProjectId/MySpaceId/MyDocumentId/workitem_MyWorkItemId"
+            }
+          }
+        }
+      },
+      "overwriteDocumentPartsResponseBody" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "overwrittenParts" : {
+                "type" : "array",
+                "description" : "Array of Part ID mappings showing old and new IDs.",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "newPartId" : {
+                      "type" : "string",
+                      "description" : "New Part ID after overwrite operation.",
+                      "example" : "MyProjectId/MySpaceId/MyDocumentId/workitem_MyWorkItemId"
+                    },
+                    "oldPartId" : {
+                      "type" : "string",
+                      "description" : "Original Part ID before overwrite operation.",
+                      "example" : "MyProjectId/MySpaceId/MyDocumentId/workitem_MyWorkItemId"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -49322,6 +53597,32 @@
                 "limited" : {
                   "type" : "boolean",
                   "example" : true
+                },
+                "linkRules" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "fromTypes" : {
+                        "type" : "array",
+                        "example" : [ "requirement" ],
+                        "items" : {
+                          "type" : "string"
+                        }
+                      },
+                      "toTypes" : {
+                        "type" : "array",
+                        "example" : [ "requirement" ],
+                        "items" : {
+                          "type" : "string"
+                        }
+                      },
+                      "sameType" : {
+                        "type" : "boolean",
+                        "example" : false
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -49450,87 +53751,40 @@
       "fieldsMetadataActionResponseBody" : {
         "type" : "object",
         "properties" : {
-          "links" : {
-            "type" : "object",
-            "properties" : {
-              "self" : {
-                "type" : "string",
-                "example" : "http://localhost:8888/polarion/rest/v1/projects/MyProjectId/actions/getFieldsMetadata?resourceType=MyResourceType&targetType=MyTargetType"
-              }
-            }
-          },
           "data" : {
             "type" : "object",
             "properties" : {
               "attributes" : {
                 "type" : "object",
                 "properties" : {
-                  "enumField" : {
+                  "structField" : {
                     "type" : "object",
                     "properties" : {
-                      "label" : {
-                        "type" : "string",
-                        "example" : "field-label"
-                      },
                       "type" : {
                         "type" : "object",
                         "properties" : {
-                          "enumContext" : {
+                          "structureName" : {
                             "type" : "string",
-                            "example" : "enum-context"
+                            "example" : "structureId"
                           },
                           "kind" : {
                             "type" : "string",
-                            "example" : "enumeration"
-                          },
-                          "enumName" : {
-                            "type" : "string",
-                            "example" : "enum-name"
+                            "example" : "structure"
                           }
                         }
-                      }
-                    }
-                  },
-                  "primitiveField" : {
-                    "type" : "object",
-                    "properties" : {
+                      },
                       "label" : {
                         "type" : "string",
                         "example" : "field-label"
-                      },
-                      "type" : {
-                        "type" : "object",
-                        "properties" : {
-                          "kind" : {
-                            "type" : "object",
-                            "properties" : {
-                              "enum" : {
-                                "type" : "array",
-                                "items" : {
-                                  "type" : "string",
-                                  "enum" : [ "string", "text", "text/html", "integer", "float", "currency", "time", "date", "date-time", "boolean" ]
-                                }
-                              }
-                            }
-                          }
-                        }
                       }
                     }
                   },
                   "listField" : {
                     "type" : "object",
                     "properties" : {
-                      "label" : {
-                        "type" : "string",
-                        "example" : "field-label"
-                      },
                       "type" : {
                         "type" : "object",
                         "properties" : {
-                          "kind" : {
-                            "type" : "string",
-                            "example" : "list"
-                          },
                           "itemType" : {
                             "type" : "object",
                             "properties" : {
@@ -49547,30 +53801,68 @@
                                 }
                               }
                             }
+                          },
+                          "kind" : {
+                            "type" : "string",
+                            "example" : "list"
                           }
                         }
-                      }
-                    }
-                  },
-                  "structField" : {
-                    "type" : "object",
-                    "properties" : {
+                      },
                       "label" : {
                         "type" : "string",
                         "example" : "field-label"
-                      },
+                      }
+                    }
+                  },
+                  "primitiveField" : {
+                    "type" : "object",
+                    "properties" : {
                       "type" : {
                         "type" : "object",
                         "properties" : {
                           "kind" : {
-                            "type" : "string",
-                            "example" : "structure"
-                          },
-                          "structureName" : {
-                            "type" : "string",
-                            "example" : "structureId"
+                            "type" : "object",
+                            "properties" : {
+                              "enum" : {
+                                "type" : "array",
+                                "items" : {
+                                  "type" : "string",
+                                  "enum" : [ "string", "text", "text/html", "integer", "float", "currency", "time", "date", "date-time", "boolean" ]
+                                }
+                              }
+                            }
                           }
                         }
+                      },
+                      "label" : {
+                        "type" : "string",
+                        "example" : "field-label"
+                      }
+                    }
+                  },
+                  "enumField" : {
+                    "type" : "object",
+                    "properties" : {
+                      "type" : {
+                        "type" : "object",
+                        "properties" : {
+                          "enumContext" : {
+                            "type" : "string",
+                            "example" : "enum-context"
+                          },
+                          "enumName" : {
+                            "type" : "string",
+                            "example" : "enum-name"
+                          },
+                          "kind" : {
+                            "type" : "string",
+                            "example" : "enumeration"
+                          }
+                        }
+                      },
+                      "label" : {
+                        "type" : "string",
+                        "example" : "field-label"
                       }
                     }
                   }
@@ -49582,16 +53874,12 @@
                   "relationshipField" : {
                     "type" : "object",
                     "properties" : {
-                      "label" : {
-                        "type" : "string",
-                        "example" : "field-label"
-                      },
                       "type" : {
                         "type" : "object",
                         "properties" : {
-                          "kind" : {
-                            "type" : "string",
-                            "example" : "relationship"
+                          "multi" : {
+                            "type" : "boolean",
+                            "example" : true
                           },
                           "targetResourceTypes" : {
                             "type" : "array",
@@ -49600,15 +53888,28 @@
                               "example" : "resource-type"
                             }
                           },
-                          "multi" : {
-                            "type" : "boolean",
-                            "example" : true
+                          "kind" : {
+                            "type" : "string",
+                            "example" : "relationship"
                           }
                         }
+                      },
+                      "label" : {
+                        "type" : "string",
+                        "example" : "field-label"
                       }
                     }
                   }
                 }
+              }
+            }
+          },
+          "links" : {
+            "type" : "object",
+            "properties" : {
+              "self" : {
+                "type" : "string",
+                "example" : "http://localhost:8888/polarion/rest/v1/projects/MyProjectId/actions/getFieldsMetadata?resourceType=MyResourceType&targetType=MyTargetType"
               }
             }
           }
@@ -49709,11 +54010,11 @@
         "properties" : {
           "type" : {
             "type" : "string",
-            "enum" : [ "collections", "categories", "documents", "document_attachments", "document_comments", "document_parts", "enumerations", "globalroles", "icons", "jobs", "linkedworkitems", "externallylinkedworkitems", "linkedoslcresources", "pages", "page_attachments", "page_comments", "plans", "projectroles", "projectgroups", "projects", "projecttemplates", "spaces", "testparameters", "testparameter_definitions", "testrecords", "teststep_results", "testruns", "testrun_attachments", "teststepresult_attachments", "testrun_comments", "usergroups", "users", "workitems", "workitem_attachments", "workitem_approvals", "workitem_comments", "featureselections", "teststeps", "workrecords", "revisions", "testrecord_attachments", "license_slots", "license_types", "license", "metadata", "license_assignments", "customfields" ]
+            "enum" : [ "collections", "categories", "documents", "document_attachments", "document_comments", "document_parts", "enumerations", "globalroles", "icons", "jobs", "linkedworkitems", "externallylinkedworkitems", "linkedoslcresources", "llms", "pages", "page_attachments", "page_comments", "plans", "projectroles", "projectgroups", "projects", "projecttemplates", "spaces", "testparameters", "testparameter_definitions", "testrecords", "teststep_results", "testruns", "testrun_attachments", "teststepresult_attachments", "testrun_comments", "usergroups", "users", "workitems", "workitem_attachments", "workitem_approvals", "workitem_comments", "featureselections", "teststeps", "workrecords", "revisions", "testrecord_attachments", "license_slots", "license_types", "license", "metadata", "license_assignments", "customfields" ]
           },
           "id" : {
             "type" : "string",
-            "example" : "MyProjectId/MyResourceId"
+            "example" : "MyResourceId"
           }
         }
       },
@@ -49741,8 +54042,8 @@
         "description" : "The Relationship's response body. Can return a single or a list of instances",
         "example" : {
           "data" : [ {
-            "type" : "MyResourceType",
-            "id" : "MyProjectId/MyResourceId"
+            "type" : "workitems",
+            "id" : "MyProjectId/WI-123"
           } ]
         },
         "oneOf" : [ {
@@ -49775,8 +54076,8 @@
         "description" : "List of generic contents",
         "example" : {
           "data" : [ {
-            "type" : "MyResourceType",
-            "id" : "MyProjectId/MyResourceId",
+            "type" : "workitems",
+            "id" : "MyProjectId/WI-123",
             "revision" : "1234"
           } ]
         },
@@ -49818,6 +54119,54 @@
           }
         }
       },
+      "importWordDocumentParameters" : {
+        "required" : [ "documentName", "documentType", "title" ],
+        "type" : "object",
+        "properties" : {
+          "documentName" : {
+            "type" : "string",
+            "description" : "Unique document name/ID for the imported document.",
+            "example" : "REQ-001"
+          },
+          "title" : {
+            "type" : "string",
+            "description" : "Title for the imported document.",
+            "example" : "System Requirements"
+          },
+          "documentType" : {
+            "type" : "string",
+            "description" : "Document type for the imported document (e.g., 'generic').",
+            "example" : "generic"
+          },
+          "configurationId" : {
+            "type" : "string",
+            "description" : "Optional configuration ID referencing a preexisting import configuration template. If not provided, default import behavior will be used.",
+            "example" : "Default.xml"
+          }
+        },
+        "description" : "Parameters for Word document import",
+        "example" : {
+          "documentName" : "REQ-001",
+          "title" : "System Requirements",
+          "documentType" : "generic",
+          "configurationId" : "Default.xml"
+        }
+      },
+      "importWordDocumentRequestBody" : {
+        "required" : [ "file", "parameters" ],
+        "type" : "object",
+        "properties" : {
+          "file" : {
+            "type" : "string",
+            "description" : "Word document file (.docx) to import.",
+            "format" : "binary"
+          },
+          "parameters" : {
+            "$ref" : "#/components/schemas/importWordDocumentParameters"
+          }
+        },
+        "description" : "Request body for importing a Word document"
+      },
       "PostIconsRequestBody" : {
         "title" : "PostIconsRequestBody",
         "type" : "object",
@@ -49835,13 +54184,94 @@
           }
         }
       },
+      "GenerateCompletionMessage" : {
+        "required" : [ "content", "role" ],
+        "type" : "object",
+        "properties" : {
+          "role" : {
+            "type" : "string",
+            "description" : "Role of the message sender, e.g., 'user' or 'assistant.'",
+            "example" : "user"
+          },
+          "content" : {
+            "type" : "string",
+            "description" : "Content of the message."
+          }
+        },
+        "description" : "A message in the LLM completion generation request or response."
+      },
+      "GenerateCompletionResult" : {
+        "required" : [ "message" ],
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "$ref" : "#/components/schemas/GenerateCompletionMessage"
+          }
+        },
+        "description" : "The result of a completion generation request."
+      },
+      "generateCompletionResponseBody" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/GenerateCompletionResult"
+          }
+        },
+        "description" : "Response body for LLM completion generation."
+      },
+      "GenerateCompletionResponseFormat" : {
+        "required" : [ "type" ],
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "type" : "string",
+            "description" : "Type of the response format. Defaults to 'text'.",
+            "example" : "jsonSchema",
+            "enum" : [ "text", "json", "jsonSchema" ]
+          },
+          "schema" : {
+            "type" : "object",
+            "description" : "The JSON schema to use when type is 'jsonSchema'.",
+            "example" : {
+              "type" : "object",
+              "properties" : {
+                "result" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "description" : "Response format for LLM completion generation."
+      },
+      "generateCompletionRequestBody" : {
+        "required" : [ "messages" ],
+        "type" : "object",
+        "properties" : {
+          "model" : {
+            "type" : "string",
+            "description" : "Name of the LLM to use. If not specified, the default model will be used, if available."
+          },
+          "messages" : {
+            "type" : "array",
+            "description" : "Prompt messages.",
+            "items" : {
+              "$ref" : "#/components/schemas/GenerateCompletionMessage"
+            }
+          },
+          "responseFormat" : {
+            "$ref" : "#/components/schemas/GenerateCompletionResponseFormat"
+          }
+        },
+        "description" : "Generate completion parameters."
+      },
       "RelationshipsRequestBody" : {
         "type" : "object",
         "description" : "List of generic contents",
         "example" : {
           "data" : [ {
-            "type" : "MyResourceType",
-            "id" : "MyProjectId/MyResourceId"
+            "type" : "workitems",
+            "id" : "MyProjectId/WI-123"
           } ]
         },
         "oneOf" : [ {

--- a/python_sbb_polarion/core/polarion_api/_documents/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_documents/_crud.py
@@ -11,7 +11,7 @@ from python_sbb_polarion.core.polarion_api._base import PAGE_NUMBER, PAGE_SIZE, 
 if TYPE_CHECKING:
     from requests import Response
 
-    from python_sbb_polarion.types import JsonDict, SparseFields
+    from python_sbb_polarion.types import FilesDict, JsonDict, SparseFields
 
 
 class DocumentsCrudMixin(BaseMixin):
@@ -312,3 +312,38 @@ class DocumentsCrudMixin(BaseMixin):
         if sort:
             params["sort"] = sort
         return self.polarion_connection.api_request_get(url, params=params or None)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="POST",
+        path="/projects/{projectId}/spaces/{spaceId}/documents/actions/importWordDocument",
+        path_params={
+            "projectId": "project_id",
+            "spaceId": "space_id",
+        },
+        multipart_fields={
+            "file": "files",
+            "parameters": "files",
+        },
+        required_params=["projectId", "spaceId"],
+        response_type="json",
+    )
+    def import_word_document(
+        self,
+        project_id: str,
+        space_id: str,
+        files: FilesDict,
+    ) -> Response:
+        """Import a Word document to create a new Polarion document.
+
+        Args:
+            project_id: Project identifier
+            space_id: Space identifier
+            files: Files dict with 'file' (the .docx content) and 'parameters' (JSON import parameters)
+
+        Returns:
+            Response: Created document data from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/spaces/{space_id}/documents/actions/importWordDocument"
+        return self.polarion_connection.api_request_post(url, files=files)

--- a/python_sbb_polarion/core/polarion_api/_documents/_fields.py
+++ b/python_sbb_polarion/core/polarion_api/_documents/_fields.py
@@ -159,3 +159,35 @@ class DocumentsFieldsMixin(BaseMixin):
         if document_type:
             params["type"] = document_type
         return self.polarion_connection.api_request_get(url, params=params or None)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="GET",
+        path="/projects/{projectId}/spaces/{spaceId}/documents/{documentName}/actions/getFieldsMetadata",
+        path_params={
+            "projectId": "project_id",
+            "spaceId": "space_id",
+            "documentName": "document_name",
+        },
+        required_params=["projectId", "spaceId", "documentName"],
+        response_type="json",
+    )
+    def get_document_fields_metadata(
+        self,
+        project_id: str,
+        space_id: str,
+        document_name: str,
+    ) -> Response:
+        """Get fields metadata for a document.
+
+        Args:
+            project_id: Project identifier
+            space_id: Space identifier
+            document_name: Document name
+
+        Returns:
+            Response: Document fields metadata from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/spaces/{space_id}/documents/{document_name}/actions/getFieldsMetadata"
+        return self.polarion_connection.api_request_get(url)

--- a/python_sbb_polarion/core/polarion_api/_documents/_parts.py
+++ b/python_sbb_polarion/core/polarion_api/_documents/_parts.py
@@ -197,3 +197,71 @@ class DocumentsPartsMixin(BaseMixin):
         """
         url: str = f"{self.base_url}/projects/{project_id}/spaces/{space_id}/documents/{document_name}/parts/{part_id}/actions/move"
         return self.polarion_connection.api_request_post(url, data=data)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="DELETE",
+        path="/projects/{projectId}/spaces/{spaceId}/documents/{documentName}/parts",
+        path_params={
+            "projectId": "project_id",
+            "spaceId": "space_id",
+            "documentName": "document_name",
+        },
+        body_param="data",
+        required_params=["projectId", "spaceId", "documentName"],
+        response_type="json",
+    )
+    def delete_document_parts(
+        self,
+        project_id: str,
+        space_id: str,
+        document_name: str,
+        data: JsonDict,
+    ) -> Response:
+        """Delete a list of document parts.
+
+        Args:
+            project_id: Project identifier
+            space_id: Space identifier
+            document_name: Document name
+            data: Document parts to delete in JSON:API format
+
+        Returns:
+            Response: Deletion result from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/spaces/{space_id}/documents/{document_name}/parts"
+        return self.polarion_connection.api_request_delete(url, data=data)
+
+    @restapi_endpoint(
+        method="POST",
+        path="/projects/{projectId}/spaces/{spaceId}/documents/{documentName}/parts/actions/overwrite",
+        path_params={
+            "projectId": "project_id",
+            "spaceId": "space_id",
+            "documentName": "document_name",
+        },
+        body_param="data",
+        required_params=["projectId", "spaceId", "documentName"],
+        response_type="json",
+    )
+    def overwrite_document_parts(
+        self,
+        project_id: str,
+        space_id: str,
+        document_name: str,
+        data: JsonDict,
+    ) -> Response:
+        """Overwrite multiple work item document parts.
+
+        Args:
+            project_id: Project identifier
+            space_id: Space identifier
+            document_name: Document name
+            data: Document parts data in JSON:API format
+
+        Returns:
+            Response: Overwrite operation result from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/spaces/{space_id}/documents/{document_name}/parts/actions/overwrite"
+        return self.polarion_connection.api_request_post(url, data=data)

--- a/python_sbb_polarion/core/polarion_api/_documents/_parts.py
+++ b/python_sbb_polarion/core/polarion_api/_documents/_parts.py
@@ -209,7 +209,7 @@ class DocumentsPartsMixin(BaseMixin):
             "documentName": "document_name",
         },
         body_param="data",
-        required_params=["projectId", "spaceId", "documentName"],
+        required_params=["projectId", "spaceId", "documentName", "__request_body__"],
         response_type="json",
     )
     def delete_document_parts(
@@ -242,7 +242,7 @@ class DocumentsPartsMixin(BaseMixin):
             "documentName": "document_name",
         },
         body_param="data",
-        required_params=["projectId", "spaceId", "documentName"],
+        required_params=["projectId", "spaceId", "documentName", "__request_body__"],
         response_type="json",
     )
     def overwrite_document_parts(

--- a/python_sbb_polarion/core/polarion_api/_license/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_license/_crud.py
@@ -324,7 +324,7 @@ class LicenseMixin(BaseMixin):
         path="/license/assignments/{userId}",
         path_params={"userId": "user_id"},
         body_param="data",
-        required_params=["userId"],
+        required_params=["userId", "__request_body__"],
         response_type="json",
     )
     def update_license_assignment(

--- a/python_sbb_polarion/core/polarion_api/_license/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_license/_crud.py
@@ -316,3 +316,32 @@ class LicenseMixin(BaseMixin):
         """
         url: str = f"{self.base_url}/license/assignments"
         return self.polarion_connection.api_request_patch(url, data=data)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="PATCH",
+        path="/license/assignments/{userId}",
+        path_params={"userId": "user_id"},
+        body_param="data",
+        required_params=["userId"],
+        response_type="json",
+    )
+    def update_license_assignment(
+        self,
+        user_id: str,
+        data: JsonDict,
+    ) -> Response:
+        """Update a user's license assignment.
+
+        Note: Not supported by cloud-based Polarion X.
+
+        Args:
+            user_id: User identifier
+            data: License assignment data in JSON:API format
+
+        Returns:
+            Response: Updated assignment data from API
+        """
+        url: str = f"{self.base_url}/license/assignments/{user_id}"
+        return self.polarion_connection.api_request_patch(url, data=data)

--- a/python_sbb_polarion/core/polarion_api/_llms/__init__.py
+++ b/python_sbb_polarion/core/polarion_api/_llms/__init__.py
@@ -1,0 +1,6 @@
+"""LLMs (Large Language Models) module."""
+
+from python_sbb_polarion.core.polarion_api._llms._crud import LlmsMixin
+
+
+__all__ = ["LlmsMixin"]

--- a/python_sbb_polarion/core/polarion_api/_llms/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_llms/_crud.py
@@ -56,6 +56,7 @@ class LlmsMixin(BaseMixin):
         method="POST",
         path="/llms/actions/generateCompletion",
         body_param="data",
+        required_params=["__request_body__"],
         response_type="json",
     )
     def generate_completion(

--- a/python_sbb_polarion/core/polarion_api/_llms/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_llms/_crud.py
@@ -58,7 +58,7 @@ class LlmsMixin(BaseMixin):
         body_param="data",
         response_type="json",
     )
-    def create_completion(
+    def generate_completion(
         self,
         data: JsonDict,
     ) -> Response:

--- a/python_sbb_polarion/core/polarion_api/_llms/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_llms/_crud.py
@@ -1,0 +1,74 @@
+"""LLMs (Large Language Models) operations mixin."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from python_sbb_polarion.core.annotations import restapi_endpoint
+from python_sbb_polarion.core.polarion_api._base import PAGE_NUMBER, PAGE_SIZE, BaseMixin
+
+
+if TYPE_CHECKING:
+    from requests import Response
+
+    from python_sbb_polarion.types import JsonDict
+
+
+class LlmsMixin(BaseMixin):
+    """LLMs operations.
+
+    Provides methods for listing Large Language Models and generating chat completions.
+    New in Polarion 2606.
+    """
+
+    @restapi_endpoint(
+        method="GET",
+        path="/llms",
+        query_params={
+            PAGE_SIZE: "page_size",
+            PAGE_NUMBER: "page_number",
+        },
+        response_type="json",
+    )
+    def get_llms(
+        self,
+        page_size: int | None = None,
+        page_number: int | None = None,
+    ) -> Response:
+        """Get list of available Large Language Models (LLMs).
+
+        Args:
+            page_size: Number of items per page
+            page_number: Page number (1-based)
+
+        Returns:
+            Response: List of LLMs from API
+        """
+        url: str = f"{self.base_url}/llms"
+        params: dict[str, str] = {}
+        if page_size is not None:
+            params[PAGE_SIZE] = str(page_size)
+        if page_number is not None:
+            params[PAGE_NUMBER] = str(page_number)
+        return self.polarion_connection.api_request_get(url, params=params or None)
+
+    @restapi_endpoint(
+        method="POST",
+        path="/llms/actions/generateCompletion",
+        body_param="data",
+        response_type="json",
+    )
+    def create_completion(
+        self,
+        data: JsonDict,
+    ) -> Response:
+        """Generate a chat completion using a Large Language Model (LLM).
+
+        Args:
+            data: Completion request data in JSON:API format
+
+        Returns:
+            Response: Generated completion from API
+        """
+        url: str = f"{self.base_url}/llms/actions/generateCompletion"
+        return self.polarion_connection.api_request_post(url, data=data)

--- a/python_sbb_polarion/core/polarion_api/_plans/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_plans/_crud.py
@@ -386,3 +386,32 @@ class PlansMixin(BaseMixin):
         """
         url: str = f"{self.base_url}/projects/{project_id}/plans/{plan_id}/relationships/{relationship_id}"
         return self.polarion_connection.api_request_delete(url, data=data)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="GET",
+        path="/projects/{projectId}/plans/{planId}/actions/getFieldsMetadata",
+        path_params={
+            "projectId": "project_id",
+            "planId": "plan_id",
+        },
+        required_params=["projectId", "planId"],
+        response_type="json",
+    )
+    def get_plan_fields_metadata(
+        self,
+        project_id: str,
+        plan_id: str,
+    ) -> Response:
+        """Get fields metadata for a plan.
+
+        Args:
+            project_id: Project identifier
+            plan_id: Plan identifier
+
+        Returns:
+            Response: Plan fields metadata from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/plans/{plan_id}/actions/getFieldsMetadata"
+        return self.polarion_connection.api_request_get(url)

--- a/python_sbb_polarion/core/polarion_api/_projects/_collections.py
+++ b/python_sbb_polarion/core/polarion_api/_projects/_collections.py
@@ -467,3 +467,32 @@ class ProjectsCollectionsMixin(BaseMixin):
         if revision:
             params["revision"] = revision
         return self.polarion_connection.api_request_post(url, data=data, params=params or None)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="GET",
+        path="/projects/{projectId}/collections/{collectionId}/actions/getFieldsMetadata",
+        path_params={
+            "projectId": "project_id",
+            "collectionId": "collection_id",
+        },
+        required_params=["projectId", "collectionId"],
+        response_type="json",
+    )
+    def get_collection_fields_metadata(
+        self,
+        project_id: str,
+        collection_id: str,
+    ) -> Response:
+        """Get fields metadata for a collection.
+
+        Args:
+            project_id: Project identifier
+            collection_id: Collection identifier
+
+        Returns:
+            Response: Collection fields metadata from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/collections/{collection_id}/actions/getFieldsMetadata"
+        return self.polarion_connection.api_request_get(url)

--- a/python_sbb_polarion/core/polarion_api/_testruns/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_testruns/_crud.py
@@ -427,3 +427,32 @@ class TestrunsCrudMixin(BaseMixin):
         """
         url: str = f"{self.base_url}/projects/{project_id}/testruns/{testrun_id}/actions/importXUnitTestResults"
         return self.polarion_connection.api_request_post(url, files=files)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="GET",
+        path="/projects/{projectId}/testruns/{testRunId}/actions/getFieldsMetadata",
+        path_params={
+            "projectId": "project_id",
+            "testRunId": "testrun_id",
+        },
+        required_params=["projectId", "testRunId"],
+        response_type="json",
+    )
+    def get_testrun_fields_metadata(
+        self,
+        project_id: str,
+        testrun_id: str,
+    ) -> Response:
+        """Get fields metadata for a test run.
+
+        Args:
+            project_id: Project identifier
+            testrun_id: Test run identifier
+
+        Returns:
+            Response: Test run fields metadata from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/testruns/{testrun_id}/actions/getFieldsMetadata"
+        return self.polarion_connection.api_request_get(url)

--- a/python_sbb_polarion/core/polarion_api/_testruns/_records.py
+++ b/python_sbb_polarion/core/polarion_api/_testruns/_records.py
@@ -807,3 +807,41 @@ class TestrunsRecordsMixin(BaseMixin):
         """
         url: str = f"{self.base_url}/projects/{project_id}/testruns/{testrun_id}/testrecords/{test_case_project_id}/{test_case_id}/{iteration}/testparameters/{test_param_id}"
         return self.polarion_connection.api_request_delete(url)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="GET",
+        path="/projects/{projectId}/testruns/{testRunId}/testrecords/{testCaseProjectId}/{testCaseId}/{iteration}/actions/getFieldsMetadata",
+        path_params={
+            "projectId": "project_id",
+            "testRunId": "testrun_id",
+            "testCaseProjectId": "test_case_project_id",
+            "testCaseId": "test_case_id",
+            "iteration": "iteration",
+        },
+        required_params=["projectId", "testRunId", "testCaseProjectId", "testCaseId", "iteration"],
+        response_type="json",
+    )
+    def get_testrecord_fields_metadata(
+        self,
+        project_id: str,
+        testrun_id: str,
+        test_case_project_id: str,
+        test_case_id: str,
+        iteration: int,
+    ) -> Response:
+        """Get fields metadata for a test record.
+
+        Args:
+            project_id: Project identifier
+            testrun_id: Test run identifier
+            test_case_project_id: Test case project identifier
+            test_case_id: Test case identifier
+            iteration: Iteration number
+
+        Returns:
+            Response: Test record fields metadata from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/testruns/{testrun_id}/testrecords/{test_case_project_id}/{test_case_id}/{iteration}/actions/getFieldsMetadata"
+        return self.polarion_connection.api_request_get(url)

--- a/python_sbb_polarion/core/polarion_api/_workitems/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_workitems/_crud.py
@@ -369,7 +369,7 @@ class WorkitemsCrudMixin(BaseMixin):
             "projectId": "project_id",
         },
         body_param="data",
-        required_params=["projectId"],
+        required_params=["projectId", "__request_body__"],
         response_type="json",
     )
     def move_workitems_to_document(self, project_id: str, data: JsonDict) -> Response:

--- a/python_sbb_polarion/core/polarion_api/_workitems/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_workitems/_crud.py
@@ -359,3 +359,28 @@ class WorkitemsCrudMixin(BaseMixin):
         """
         url: str = f"{self.base_url}/projects/{project_id}/workitems/{workitem_id}/actions/moveFromDocument"
         return self.polarion_connection.api_request_post(url, data=data)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="POST",
+        path="/projects/{projectId}/workitems/actions/moveToDocument",
+        path_params={
+            "projectId": "project_id",
+        },
+        body_param="data",
+        required_params=["projectId"],
+        response_type="json",
+    )
+    def move_workitems_to_document(self, project_id: str, data: JsonDict) -> Response:
+        """Move multiple work items into a document.
+
+        Args:
+            project_id: Project identifier
+            data: Work items and target document specification in JSON:API format
+
+        Returns:
+            Response: Response from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/workitems/actions/moveToDocument"
+        return self.polarion_connection.api_request_post(url, data=data)

--- a/python_sbb_polarion/core/polarion_api/_workitems/_fields.py
+++ b/python_sbb_polarion/core/polarion_api/_workitems/_fields.py
@@ -428,3 +428,32 @@ class WorkitemsFieldsMixin(BaseMixin):
         if revision:
             params["revision"] = revision
         return self.polarion_connection.api_request_get(url, params=params or None)
+
+    # New endpoints in Polarion 2606
+
+    @restapi_endpoint(
+        method="GET",
+        path="/projects/{projectId}/workitems/{workItemId}/actions/getFieldsMetadata",
+        path_params={
+            "projectId": "project_id",
+            "workItemId": "workitem_id",
+        },
+        required_params=["projectId", "workItemId"],
+        response_type="json",
+    )
+    def get_workitem_fields_metadata(
+        self,
+        project_id: str,
+        workitem_id: str,
+    ) -> Response:
+        """Get fields metadata for a work item.
+
+        Args:
+            project_id: Project identifier
+            workitem_id: Work item identifier
+
+        Returns:
+            Response: Work item fields metadata from API
+        """
+        url: str = f"{self.base_url}/projects/{project_id}/workitems/{workitem_id}/actions/getFieldsMetadata"
+        return self.polarion_connection.api_request_get(url)

--- a/python_sbb_polarion/core/polarion_api/polarion_api_v1.py
+++ b/python_sbb_polarion/core/polarion_api/polarion_api_v1.py
@@ -34,6 +34,9 @@ from python_sbb_polarion.core.polarion_api._jobs import JobsManagementMixin
 # License
 from python_sbb_polarion.core.polarion_api._license import LicenseMixin
 
+# LLMs (new in Polarion 2606)
+from python_sbb_polarion.core.polarion_api._llms import LlmsMixin
+
 # Pages
 from python_sbb_polarion.core.polarion_api._pages import PagesMixin
 
@@ -110,6 +113,8 @@ class PolarionApiV1(
     PagesMixin,
     # License
     LicenseMixin,
+    # LLMs
+    LlmsMixin,
     # Custom Fields
     CustomFieldsMixin,
     # Global
@@ -124,8 +129,8 @@ class PolarionApiV1(
 ):
     """Polarion REST API v1 - Full implementation.
 
-    Provides comprehensive access to the Polarion REST API v1 with ~271 operations
-    covering all resources (based on Polarion 2512):
+    Provides comprehensive access to the Polarion REST API v1 with ~284 operations
+    covering all resources (based on Polarion 2606):
 
     - **Workitems**: CRUD, attachments, comments, links, backlinks, approvals, test steps, work records
     - **Testruns**: CRUD, attachments, comments, records, step results, parameters

--- a/tests/unit/core/test_polarion_api_v1.py
+++ b/tests/unit/core/test_polarion_api_v1.py
@@ -1,4 +1,4 @@
-"""Unit tests for PolarionApiV1 - complete coverage of all 212 methods."""
+"""Unit tests for PolarionApiV1 - complete coverage of all API methods."""
 
 from __future__ import annotations
 
@@ -4360,12 +4360,12 @@ class TestPolarion2606New(unittest.TestCase):
         self.assertEqual(params[PAGE_SIZE], "10")
         self.assertEqual(params[PAGE_NUMBER], "1")
 
-    def test_create_completion(self) -> None:
-        """Test create_completion method."""
+    def test_generate_completion(self) -> None:
+        """Test generate_completion method."""
         data: JsonDict = {
             "data": {"type": "completions"},
         }
-        self.api.create_completion(data)
+        self.api.generate_completion(data)
         call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_post.call_args
         self.assertIn("/llms/actions/generateCompletion", call_args[0][0])
 

--- a/tests/unit/core/test_polarion_api_v1.py
+++ b/tests/unit/core/test_polarion_api_v1.py
@@ -4250,5 +4250,125 @@ class TestLicenseOptionalParams(unittest.TestCase):
         self.assertEqual(params["include"], "licenseType")
 
 
+# =============================================================================
+# Polarion 2606 New Endpoints Tests (13 methods)
+# =============================================================================
+
+
+class TestPolarion2606New(unittest.TestCase):
+    """Test new operations introduced in Polarion 2606."""
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        from python_sbb_polarion.core.polarion_api import PolarionApiV1
+
+        self.mock_connection: MagicMock = MagicMock()
+        self.api: PolarionApiV1 = PolarionApiV1(self.mock_connection)
+
+    def test_delete_document_parts(self) -> None:
+        """Test delete_document_parts method."""
+        data: JsonDict = {
+            "data": [{"type": "document_parts", "id": "project1/space/doc1/part-1"}],
+        }
+        self.api.delete_document_parts("project1", "space", "doc1", data)
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_delete.call_args
+        self.assertIn("/projects/project1/spaces/space/documents/doc1/parts", call_args[0][0])
+
+    def test_overwrite_document_parts(self) -> None:
+        """Test overwrite_document_parts method."""
+        data: JsonDict = {
+            "data": [{"type": "document_parts"}],
+        }
+        self.api.overwrite_document_parts("project1", "space", "doc1", data)
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_post.call_args
+        self.assertIn("/projects/project1/spaces/space/documents/doc1/parts/actions/overwrite", call_args[0][0])
+
+    def test_import_word_document(self) -> None:
+        """Test import_word_document method."""
+        files: dict[str, tuple[str, bytes]] = {
+            "file": ("doc.docx", b"content"),
+        }
+        self.api.import_word_document("project1", "space", files)
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_post.call_args
+        self.assertIn("/projects/project1/spaces/space/documents/actions/importWordDocument", call_args[0][0])
+
+    def test_get_document_fields_metadata(self) -> None:
+        """Test get_document_fields_metadata method."""
+        self.api.get_document_fields_metadata("project1", "space", "doc1")
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_get.call_args
+        self.assertIn("/projects/project1/spaces/space/documents/doc1/actions/getFieldsMetadata", call_args[0][0])
+
+    def test_get_workitem_fields_metadata(self) -> None:
+        """Test get_workitem_fields_metadata method."""
+        self.api.get_workitem_fields_metadata("project1", "WI-123")
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_get.call_args
+        self.assertIn("/projects/project1/workitems/WI-123/actions/getFieldsMetadata", call_args[0][0])
+
+    def test_get_collection_fields_metadata(self) -> None:
+        """Test get_collection_fields_metadata method."""
+        self.api.get_collection_fields_metadata("project1", "coll-1")
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_get.call_args
+        self.assertIn("/projects/project1/collections/coll-1/actions/getFieldsMetadata", call_args[0][0])
+
+    def test_get_plan_fields_metadata(self) -> None:
+        """Test get_plan_fields_metadata method."""
+        self.api.get_plan_fields_metadata("project1", "plan-1")
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_get.call_args
+        self.assertIn("/projects/project1/plans/plan-1/actions/getFieldsMetadata", call_args[0][0])
+
+    def test_get_testrun_fields_metadata(self) -> None:
+        """Test get_testrun_fields_metadata method."""
+        self.api.get_testrun_fields_metadata("project1", "tr-1")
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_get.call_args
+        self.assertIn("/projects/project1/testruns/tr-1/actions/getFieldsMetadata", call_args[0][0])
+
+    def test_get_testrecord_fields_metadata(self) -> None:
+        """Test get_testrecord_fields_metadata method."""
+        self.api.get_testrecord_fields_metadata("project1", "tr-1", "tcproj", "tc-1", 0)
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_get.call_args
+        self.assertIn("/projects/project1/testruns/tr-1/testrecords/tcproj/tc-1/0/actions/getFieldsMetadata", call_args[0][0])
+
+    def test_update_license_assignment(self) -> None:
+        """Test update_license_assignment method."""
+        data: JsonDict = {
+            "data": {"type": "license_assignments"},
+        }
+        self.api.update_license_assignment("user1", data)
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_patch.call_args
+        self.assertIn("/license/assignments/user1", call_args[0][0])
+
+    def test_move_workitems_to_document(self) -> None:
+        """Test move_workitems_to_document method."""
+        data: JsonDict = {
+            "data": [{"type": "workitems", "id": "project1/WI-123"}],
+        }
+        self.api.move_workitems_to_document("project1", data)
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_post.call_args
+        self.assertIn("/projects/project1/workitems/actions/moveToDocument", call_args[0][0])
+
+    def test_get_llms(self) -> None:
+        """Test get_llms method."""
+        self.api.get_llms()
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_get.call_args
+        self.assertIn("/llms", call_args[0][0])
+
+    def test_get_llms_with_params(self) -> None:
+        """Test get_llms with pagination parameters."""
+        self.api.get_llms(page_size=10, page_number=1)
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_get.call_args
+        params: dict[str, str] = call_args[1]["params"]  # type: ignore[assignment]
+        self.assertEqual(params[PAGE_SIZE], "10")
+        self.assertEqual(params[PAGE_NUMBER], "1")
+
+    def test_create_completion(self) -> None:
+        """Test create_completion method."""
+        data: JsonDict = {
+            "data": {"type": "completions"},
+        }
+        self.api.create_completion(data)
+        call_args: tuple[tuple[str, ...], dict[str, object]] = self.mock_connection.api_request_post.call_args
+        self.assertIn("/llms/actions/generateCompletion", call_args[0][0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/verification/method_naming.py
+++ b/tests/verification/method_naming.py
@@ -44,7 +44,7 @@ class ValidationStatus(StrEnum):
 
 
 # Valid starting verbs for method names (grouped by category)
-CRUD_VERBS = frozenset({"get", "create", "update", "delete", "save", "remove", "add", "set", "clear", "attach"})
+CRUD_VERBS = frozenset({"get", "create", "update", "delete", "save", "remove", "add", "set", "clear", "attach", "overwrite"})
 ACTION_VERBS = frozenset({"start", "stop", "cancel", "run", "execute", "trigger", "enable", "disable", "activate", "wait", "promote"})
 DATA_VERBS = frozenset({"fetch", "list", "find", "search", "query", "load", "read", "write", "inspect"})
 TRANSFER_VERBS = frozenset({"import", "export", "upload", "download", "send", "sync", "push", "pull", "receive"})
@@ -123,6 +123,7 @@ HTTP_METHOD_VERBS: dict[str, frozenset[str]] = {
             "persist",
             "rename",
             "set",
+            "overwrite",
             "cancel",
             # Checks/Search (POST for complex validation/search with body)
             "validate",
@@ -133,7 +134,7 @@ HTTP_METHOD_VERBS: dict[str, frozenset[str]] = {
             "find",
         }
     ),
-    "PUT": frozenset({"update", "save", "replace", "set", "write"}),
+    "PUT": frozenset({"update", "save", "replace", "set", "write", "overwrite"}),
     "PATCH": frozenset({"update", "patch", "modify", "change", "extend", "append"}),
     "DELETE": frozenset({"delete", "remove", "cancel", "clear", "disable"}),
 }

--- a/tests/verification/test_polarion_api_v1.py
+++ b/tests/verification/test_polarion_api_v1.py
@@ -283,6 +283,7 @@ class TestPolarionApiV1MethodSignatures(unittest.TestCase):
             "set_",
             "overwrite_",
             "execute_",
+            "generate_",
             "reuse_",
         ]
 

--- a/tests/verification/test_polarion_api_v1.py
+++ b/tests/verification/test_polarion_api_v1.py
@@ -281,6 +281,7 @@ class TestPolarionApiV1MethodSignatures(unittest.TestCase):
             "export_",
             "download_",
             "set_",
+            "overwrite_",
             "execute_",
             "reuse_",
         ]

--- a/uv.lock
+++ b/uv.lock
@@ -907,7 +907,7 @@ wheels = [
 
 [[package]]
 name = "python-sbb-polarion"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
### Proposed changes

Introduce new functionality to support Large Language Models (LLMs) and enhance document management capabilities in Polarion 2606.

- Add LLMs operations for listing and generating completions
- Implement endpoints for importing Word documents and managing document parts
- Update existing methods to reflect new Polarion version

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
