### PR TITLE
feat: enhance project management with asynchronous creation and deletion using standard Polarion REST API

### DIFF
--- a/python_sbb_polarion/core/polarion_api/_projects/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_projects/_crud.py
@@ -86,6 +86,7 @@ class ProjectsCrudMixin(BaseMixin):
             "include": "include",
             "revision": "revision",
         },
+        helper_params=["print_error"],
         required_params=["projectId"],
         response_type="json",
     )
@@ -95,6 +96,7 @@ class ProjectsCrudMixin(BaseMixin):
         fields: SparseFields | None = None,
         include: str | None = None,
         revision: str | None = None,
+        print_error: bool = True,
     ) -> Response:
         """Get a specific project.
 
@@ -103,6 +105,8 @@ class ProjectsCrudMixin(BaseMixin):
             fields: JSON:API sparse fieldsets dict (e.g., {"workitems": "@all"})
             include: Include related resources
             revision: Specific revision
+            print_error: Whether to log a warning for non-2xx responses. Set to False
+                when a 404 is expected (e.g. polling for a project to appear or disappear).
 
         Returns:
             Response: Project data from API
@@ -114,7 +118,7 @@ class ProjectsCrudMixin(BaseMixin):
             params["include"] = include
         if revision:
             params["revision"] = revision
-        return self.polarion_connection.api_request_get(url, params=params or None)
+        return self.polarion_connection.api_request_get(url, params=params or None, print_error=print_error)
 
     @restapi_endpoint(
         method="POST",

--- a/python_sbb_polarion/core/polarion_api/_projects/_crud.py
+++ b/python_sbb_polarion/core/polarion_api/_projects/_crud.py
@@ -130,7 +130,8 @@ class ProjectsCrudMixin(BaseMixin):
         """Create a project.
 
         Args:
-            data: Project data in JSON:API format
+            data: Project data as a flat body (not JSON:API), e.g.
+                {"projectId": ..., "trackerPrefix": ..., "location": ..., "templateId": ...}
 
         Returns:
             Response: Created project data from API

--- a/python_sbb_polarion/testing/__init__.py
+++ b/python_sbb_polarion/testing/__init__.py
@@ -3,6 +3,7 @@
 This module contains test helpers and utilities for Polarion system tests.
 """
 
+from python_sbb_polarion.testing.errors import TempProjectError
 from python_sbb_polarion.testing.generic_test_case import GenericTestCase
 from python_sbb_polarion.testing.temp_project import TempProject
 from python_sbb_polarion.testing.testcontainers_helper import TestContainersHelper
@@ -11,5 +12,6 @@ from python_sbb_polarion.testing.testcontainers_helper import TestContainersHelp
 __all__ = [
     "GenericTestCase",
     "TempProject",
+    "TempProjectError",
     "TestContainersHelper",
 ]

--- a/python_sbb_polarion/testing/errors.py
+++ b/python_sbb_polarion/testing/errors.py
@@ -1,0 +1,12 @@
+"""Exceptions raised by the testing helpers."""
+
+from __future__ import annotations
+
+
+class TempProjectError(RuntimeError):
+    """Raised when setting up or tearing down a temporary test project fails.
+
+    Replaces the previous ``sys.exit`` calls so a failure aborts only the current
+    test (or surfaces through the CLI's exception handler) instead of killing the
+    whole process.
+    """

--- a/python_sbb_polarion/testing/generic_test_case.py
+++ b/python_sbb_polarion/testing/generic_test_case.py
@@ -153,11 +153,7 @@ class GenericTestCase(unittest.TestCase):
         Returns:
             PolarionGenericExtensionApi: Configured extension API instance
         """
-        app_url: str
-        app_token: str
-        app_url, app_token = cls.__get_parameters()
-        polarion_connection = PolarionRestApiConnection(url=app_url, token=app_token)
-        cls.__polarion_api = PolarionApiV1(polarion_connection)
+        polarion_connection: PolarionRestApiConnection = cls.__create_connection()
         return ExtensionApiFactory.get_extension_api_by_name(extension_name=extension_name, polarion_connection=polarion_connection)
 
     @classmethod
@@ -169,12 +165,22 @@ class GenericTestCase(unittest.TestCase):
         Returns:
             PolarionApiV1: Configured standard Polarion REST API client
         """
+        cls.__create_connection()
+        return cls.__polarion_api
+
+    @classmethod
+    def __create_connection(cls) -> PolarionRestApiConnection:
+        """Build a Polarion connection from APP_URL/APP_TOKEN and cache a PolarionApiV1 client.
+
+        Returns:
+            PolarionRestApiConnection: Configured connection to the Polarion REST API
+        """
         app_url: str
         app_token: str
         app_url, app_token = cls.__get_parameters()
         polarion_connection = PolarionRestApiConnection(url=app_url, token=app_token)
         cls.__polarion_api = PolarionApiV1(polarion_connection)
-        return cls.__polarion_api
+        return polarion_connection
 
     @classmethod
     def __get_parameters(cls) -> tuple[str, str]:

--- a/python_sbb_polarion/testing/generic_test_case.py
+++ b/python_sbb_polarion/testing/generic_test_case.py
@@ -161,6 +161,22 @@ class GenericTestCase(unittest.TestCase):
         return ExtensionApiFactory.get_extension_api_by_name(extension_name=extension_name, polarion_connection=polarion_connection)
 
     @classmethod
+    def create_polarion_api(cls) -> PolarionApiV1:
+        """Create the standard Polarion REST API (PolarionApiV1) client.
+
+        Builds a connection from APP_URL/APP_TOKEN parameters, mirroring create_extension_api.
+
+        Returns:
+            PolarionApiV1: Configured standard Polarion REST API client
+        """
+        app_url: str
+        app_token: str
+        app_url, app_token = cls.__get_parameters()
+        polarion_connection = PolarionRestApiConnection(url=app_url, token=app_token)
+        cls.__polarion_api = PolarionApiV1(polarion_connection)
+        return cls.__polarion_api
+
+    @classmethod
     def __get_parameters(cls) -> tuple[str, str]:
         args: argparse.Namespace = get_script_arguments()
 

--- a/python_sbb_polarion/testing/project_template_uploader.py
+++ b/python_sbb_polarion/testing/project_template_uploader.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import hashlib
 import logging
 import shutil
-import sys
 import tempfile
 import zipfile
 from http import HTTPStatus
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING
+
+from python_sbb_polarion.testing.errors import TempProjectError
 
 
 if TYPE_CHECKING:
@@ -66,10 +67,13 @@ class ProjectTemplateUploader:
 
         Returns:
             Path to created temporary zip file
+
+        Raises:
+            TempProjectError: If folder_path is not a directory
         """
         if not folder_path.is_dir():
             logger.error("Path '%s' is not a directory", folder_path)
-            sys.exit(1)
+            raise TempProjectError(f"Template path '{folder_path}' is not a directory")
 
         with tempfile.NamedTemporaryFile(
             suffix=".zip",
@@ -123,10 +127,13 @@ class ProjectTemplateUploader:
             template_id: Template identifier
             template_location: Absolute path to template folder
             transform_links: Optional mapping for link transformation e.g. {"old_project_id": "new_project_id"}
+
+        Raises:
+            TempProjectError: If the template folder is missing or the upload fails
         """
         if not template_location.exists():
             logger.error("Template folder '%s' doesn't exist", template_location)
-            sys.exit(1)
+            raise TempProjectError(f"Template folder '{template_location}' doesn't exist")
 
         zip_path: Path | None = None
         temp_folder: Path | None = None
@@ -165,7 +172,7 @@ class ProjectTemplateUploader:
                 logger.info("Template '%s' uploaded successfully", template_id)
             else:
                 logger.error("Failed to upload template '%s'", template_id)
-                sys.exit(1)
+                raise TempProjectError(f"Failed to upload template '{template_id}' (HTTP {response.status_code})")
         finally:
             # Clean up temporary zip file if it was created
             if zip_path is not None and zip_path.exists():

--- a/python_sbb_polarion/testing/temp_project.py
+++ b/python_sbb_polarion/testing/temp_project.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import logging
-import sys
 import time
 import uuid
 from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from python_sbb_polarion.testing.errors import TempProjectError
 from python_sbb_polarion.testing.generic_test_case import GenericTestCase
 from python_sbb_polarion.testing.project_template_uploader import ProjectTemplateUploader
 
@@ -26,8 +26,8 @@ logger = logging.getLogger(__name__)
 
 # Standard project create/delete endpoints are asynchronous (HTTP 202): the response carries a
 # job descriptor, so we poll that job (GET /jobs/{id}) until it reaches a terminal status.
-POLL_INTERVAL_SECONDS: float = 2.0
-POLL_MAX_ATTEMPTS: int = 60
+POLL_INTERVAL_SECONDS: float = 1.0
+POLL_MAX_ATTEMPTS: int = 120
 
 # Terminal job status types (jobsSingleGetResponse.data.attributes.status.type in the OpenAPI spec).
 JOB_STATUS_OK: str = "OK"
@@ -150,7 +150,7 @@ class TempProject:
         logger.debug("Response status: %s", response.status_code)
         logger.debug("Response headers: %s", response.headers)
         logger.debug("Response content: %s", response.content)
-        sys.exit(-1)
+        raise TempProjectError(f"Failed to {action} project '{self.temp_project_id}' (HTTP {response.status_code})")
 
     def _wait_for_job(self, response: Response, action: str) -> None:
         """Poll the job referenced by an async 202 response until it reaches a terminal status.
@@ -158,6 +158,9 @@ class TempProject:
         Args:
             response: The 202 (Accepted) response whose body carries the job descriptor
             action: Human-readable operation name for logging (e.g. "creation", "deletion")
+
+        Raises:
+            TempProjectError: If the job fails, is cancelled, or never reaches a terminal status
         """
         job_id: str = self._job_id_from_response(response, action)
         logger.info("Waiting for %s job '%s' of project '%s'...", action, job_id, self.temp_project_id)
@@ -170,19 +173,20 @@ class TempProject:
             if status_type == JOB_STATUS_OK:
                 return
             if status_type in JOB_STATUS_FAILURES:
-                logger.error("Job to %s project '%s' ended as %s: %s", action, self.temp_project_id, status_type, message)
-                sys.exit(-1)
+                raise TempProjectError(f"Job to {action} project '{self.temp_project_id}' ended as {status_type}: {message}")
             if attempt < POLL_MAX_ATTEMPTS - 1:
                 time.sleep(POLL_INTERVAL_SECONDS)
 
-        logger.error("Timed out waiting for %s job '%s' of project '%s'", action, job_id, self.temp_project_id)
-        sys.exit(-1)
+        raise TempProjectError(f"Timed out waiting for {action} job '{job_id}' of project '{self.temp_project_id}'")
 
     def _job_id_from_response(self, response: Response, action: str) -> str:
         """Extract the job id from an async 202 response body (jobsSinglePostResponse).
 
         Returns:
-            str: The job identifier; exits the process if the body has no usable job id
+            str: The job identifier
+
+        Raises:
+            TempProjectError: If the body has no usable job id
         """
         body: JsonDict = response.json()
         data: JsonValue = body.get("data")
@@ -191,7 +195,7 @@ class TempProject:
             if isinstance(job_id, str) and job_id:
                 return job_id
         logger.error("Unexpected async %s response for project '%s': %s", action, self.temp_project_id, body)
-        sys.exit(-1)
+        raise TempProjectError(f"Async {action} response for project '{self.temp_project_id}' carried no job id")
 
     @staticmethod
     def _job_status(job_body: JsonDict) -> tuple[str | None, str | None]:

--- a/python_sbb_polarion/testing/temp_project.py
+++ b/python_sbb_polarion/testing/temp_project.py
@@ -19,15 +19,19 @@ if TYPE_CHECKING:
 
     from python_sbb_polarion.core import PolarionApiV1
     from python_sbb_polarion.extensions.test_data import PolarionTestDataApi
-    from python_sbb_polarion.types import JsonDict, SparseFields
+    from python_sbb_polarion.types import JsonDict, JsonValue, SparseFields
 
 
 logger = logging.getLogger(__name__)
 
-# Standard project create/delete endpoints are asynchronous (HTTP 202): the project is not
-# ready immediately, so we poll the project resource until it reaches the desired state.
+# Standard project create/delete endpoints are asynchronous (HTTP 202): the response carries a
+# job descriptor, so we poll that job (GET /jobs/{id}) until it reaches a terminal status.
 POLL_INTERVAL_SECONDS: float = 2.0
 POLL_MAX_ATTEMPTS: int = 60
+
+# Terminal job status types (jobsSingleGetResponse.data.attributes.status.type in the OpenAPI spec).
+JOB_STATUS_OK: str = "OK"
+JOB_STATUS_FAILURES: frozenset[str] = frozenset({"FAILED", "CANCELLED"})
 
 
 class TempProject:
@@ -106,13 +110,13 @@ class TempProject:
         }
         response: Response = self.polarion_api.create_project(data)
 
-        # Project creation is asynchronous: the endpoint returns 202 (Accepted) with a job.
+        # Project creation is asynchronous: the endpoint returns 202 (Accepted) with a job descriptor.
         if response.status_code != HTTPStatus.ACCEPTED:
             self._fail("creation", response)
 
-        if not self._wait_for_project(should_exist=True):
-            logger.error("Timed out waiting for project '%s' to become available", self.temp_project_id)
-            sys.exit(-1)
+        # Wait for the job to finish: once it reports OK the project is fully created, so the
+        # name PATCH below is guaranteed to land on an existing, writable project.
+        self._wait_for_job(response, "creation")
 
         logger.info(
             "'%s' have been created in %.2f seconds",
@@ -148,26 +152,67 @@ class TempProject:
         logger.debug("Response content: %s", response.content)
         sys.exit(-1)
 
-    def _wait_for_project(self, should_exist: bool) -> bool:
-        """Poll the project resource until it reaches the desired presence state.
+    def _wait_for_job(self, response: Response, action: str) -> None:
+        """Poll the job referenced by an async 202 response until it reaches a terminal status.
 
         Args:
-            should_exist: True to wait until the project exists (200), False until it is gone (404)
-
-        Returns:
-            bool: True if the desired state was reached within the timeout, False otherwise
+            response: The 202 (Accepted) response whose body carries the job descriptor
+            action: Human-readable operation name for logging (e.g. "creation", "deletion")
         """
-        target_status: HTTPStatus = HTTPStatus.OK if should_exist else HTTPStatus.NOT_FOUND
-        logger.info("Waiting for project '%s' to be %s...", self.temp_project_id, "created" if should_exist else "deleted")
+        job_id: str = self._job_id_from_response(response, action)
+        logger.info("Waiting for %s job '%s' of project '%s'...", action, job_id, self.temp_project_id)
 
         for attempt in range(POLL_MAX_ATTEMPTS):
-            # While polling, the transient 404/200 mismatches are expected, so suppress the client's non-2xx warning.
-            response: Response = self.polarion_api.get_project(self.temp_project_id, print_error=False)
-            if response.status_code == target_status:
-                return True
+            job_body: JsonDict = self.polarion_api.get_job(job_id).json()
+            status_type: str | None
+            message: str | None
+            status_type, message = self._job_status(job_body)
+            if status_type == JOB_STATUS_OK:
+                return
+            if status_type in JOB_STATUS_FAILURES:
+                logger.error("Job to %s project '%s' ended as %s: %s", action, self.temp_project_id, status_type, message)
+                sys.exit(-1)
             if attempt < POLL_MAX_ATTEMPTS - 1:
                 time.sleep(POLL_INTERVAL_SECONDS)
-        return False
+
+        logger.error("Timed out waiting for %s job '%s' of project '%s'", action, job_id, self.temp_project_id)
+        sys.exit(-1)
+
+    def _job_id_from_response(self, response: Response, action: str) -> str:
+        """Extract the job id from an async 202 response body (jobsSinglePostResponse).
+
+        Returns:
+            str: The job identifier; exits the process if the body has no usable job id
+        """
+        body: JsonDict = response.json()
+        data: JsonValue = body.get("data")
+        if isinstance(data, dict):
+            job_id: JsonValue = data.get("id")
+            if isinstance(job_id, str) and job_id:
+                return job_id
+        logger.error("Unexpected async %s response for project '%s': %s", action, self.temp_project_id, body)
+        sys.exit(-1)
+
+    @staticmethod
+    def _job_status(job_body: JsonDict) -> tuple[str | None, str | None]:
+        """Return (status type, status message) from a job body, or (None, None) if absent.
+
+        A still-running job has no terminal status yet, hence the optional return.
+        """
+        data: JsonValue = job_body.get("data")
+        if not isinstance(data, dict):
+            return None, None
+        attributes: JsonValue = data.get("attributes")
+        if not isinstance(attributes, dict):
+            return None, None
+        status: JsonValue = attributes.get("status")
+        if not isinstance(status, dict):
+            return None, None
+        status_type: JsonValue = status.get("type")
+        message: JsonValue = status.get("message")
+        type_str: str | None = status_type if isinstance(status_type, str) else None
+        message_str: str | None = message if isinstance(message, str) else None
+        return type_str, message_str
 
     def _upload_project_template(self, transform_links: SparseFields | None = None) -> None:
         if self.temp_project_template_location is None:
@@ -186,12 +231,10 @@ class TempProject:
         start_time: float = time.time()
         response: Response = self.polarion_api.delete_project(self.temp_project_id)
 
-        # Project deletion is asynchronous: the endpoint returns 202 (Accepted).
+        # Project deletion is asynchronous: the endpoint returns 202 (Accepted) with a job descriptor.
         if response.status_code != HTTPStatus.ACCEPTED:
             self._fail("deletion", response)
 
-        if not self._wait_for_project(should_exist=False):
-            logger.error("Timed out waiting for project '%s' to be deleted", self.temp_project_id)
-            sys.exit(-1)
+        self._wait_for_job(response, "deletion")
 
         logger.info("'%s' have been deleted in %.2f seconds", self.temp_project_id, time.time() - start_time)

--- a/python_sbb_polarion/testing/temp_project.py
+++ b/python_sbb_polarion/testing/temp_project.py
@@ -15,12 +15,17 @@ from python_sbb_polarion.testing.project_template_uploader import ProjectTemplat
 if TYPE_CHECKING:
     from requests import Response
 
-    from python_sbb_polarion.extensions.admin_utility import PolarionAdminUtilityApi
+    from python_sbb_polarion.core import PolarionApiV1
     from python_sbb_polarion.extensions.test_data import PolarionTestDataApi
-    from python_sbb_polarion.types import SparseFields
+    from python_sbb_polarion.types import JsonDict, SparseFields
 
 
 logger = logging.getLogger(__name__)
+
+# Standard project create/delete endpoints are asynchronous (HTTP 202): the project is not
+# ready immediately, so we poll the project resource until it reaches the desired state.
+POLL_INTERVAL_SECONDS: float = 2.0
+POLL_MAX_ATTEMPTS: int = 60
 
 
 class TempProject:
@@ -64,6 +69,10 @@ class TempProject:
         self.temp_project_template_id: str = template_id
         self.temp_project_template_location: Path | None = template_location
 
+        # Build the API clients once up front; from here on they are always ready to use.
+        self.polarion_api: PolarionApiV1 = GenericTestCase.create_polarion_api()
+        self.test_data_api: PolarionTestDataApi = GenericTestCase.create_extension_api("test-data")
+
         self._upload_project_template(transform_links)
         self._create_temp_project()
 
@@ -71,8 +80,6 @@ class TempProject:
         return self.temp_project_id
 
     def _create_temp_project(self) -> None:
-        admin_utility_api: PolarionAdminUtilityApi = GenericTestCase.create_extension_api("admin-utility")
-
         logger.debug(
             "Creating project with id '%s' and name '%s' for template with id '%s'",
             self.temp_project_id,
@@ -80,35 +87,92 @@ class TempProject:
             self.temp_project_template_id,
         )
 
-        start_time: float = time.time()
-        response: Response = admin_utility_api.create_project(
-            project_id=self.temp_project_id,
-            project_name=self.temp_project_name,
-            template_id=self.temp_project_template_id,
-        )
-
-        if response.status_code == HTTPStatus.OK:
-            logger.info(
-                "'%s' have been created in %.2f seconds",
-                self.temp_project_id,
-                time.time() - start_time,
-            )
-        elif response.status_code == HTTPStatus.BAD_REQUEST and f"Project id '{self.temp_project_id}' clashes with existing project id '{self.temp_project_id}'." in response.text:
+        # A 404 here just means the project does not exist yet, so suppress the client's non-2xx warning.
+        existing_response: Response = self.polarion_api.get_project(self.temp_project_id, print_error=False)
+        if existing_response.status_code == HTTPStatus.OK:
             logger.info("'%s' already exists... nothing to do", self.temp_project_id)
-        else:
+            return
+
+        start_time: float = time.time()
+        # createProject expects a flat body (not JSON:API); projectId, trackerPrefix and
+        # location are required (nullable: false in the OpenAPI schema).
+        data: JsonDict = {
+            "projectId": self.temp_project_id,
+            "trackerPrefix": self.temp_project_id,
+            "location": self.temp_project_id,
+            "templateId": self.temp_project_template_id,
+        }
+        response: Response = self.polarion_api.create_project(data)
+
+        # Project creation is asynchronous: the endpoint returns 202 (Accepted) with a job.
+        if response.status_code != HTTPStatus.ACCEPTED:
             logger.error("Error during creation project '%s'", self.temp_project_id)
             logger.debug("Response status: %s", response.status_code)
             logger.debug("Response headers: %s", response.headers)
             logger.debug("Response content: %s", response.content)
             sys.exit(-1)
 
+        if not self._wait_for_project(should_exist=True):
+            logger.error("Timed out waiting for project '%s' to become available", self.temp_project_id)
+            sys.exit(-1)
+
+        logger.info(
+            "'%s' have been created in %.2f seconds",
+            self.temp_project_id,
+            time.time() - start_time,
+        )
+
+        self._set_project_name()
+
+    def _set_project_name(self) -> None:
+        # createProject does not accept a project name; set it afterwards via PATCH. Best-effort.
+        data: JsonDict = {
+            "data": {
+                "type": "projects",
+                "id": self.temp_project_id,
+                "attributes": {
+                    "name": self.temp_project_name,
+                },
+            },
+        }
+        response: Response = self.polarion_api.update_project(self.temp_project_id, data)
+        if response.status_code not in {HTTPStatus.OK, HTTPStatus.NO_CONTENT}:
+            logger.warning(
+                "Could not set name for project '%s' (status %s)",
+                self.temp_project_id,
+                response.status_code,
+            )
+
+    def _wait_for_project(self, should_exist: bool) -> bool:
+        """Poll the project resource until it reaches the desired presence state.
+
+        Args:
+            should_exist: True to wait until the project exists (200), False until it is gone (404)
+
+        Returns:
+            bool: True if the desired state was reached within the timeout, False otherwise
+        """
+        if should_exist:
+            logger.info("Waiting for project '%s' to be created...", self.temp_project_id)
+        else:
+            logger.info("Waiting for project '%s' to be deleted...", self.temp_project_id)
+
+        for _ in range(POLL_MAX_ATTEMPTS):
+            # While polling, the transient 404/200 mismatches are expected, so suppress the client's non-2xx warning.
+            response: Response = self.polarion_api.get_project(self.temp_project_id, print_error=False)
+            if should_exist and response.status_code == HTTPStatus.OK:
+                return True
+            if not should_exist and response.status_code == HTTPStatus.NOT_FOUND:
+                return True
+            time.sleep(POLL_INTERVAL_SECONDS)
+        return False
+
     def _upload_project_template(self, transform_links: SparseFields | None = None) -> None:
         if self.temp_project_template_location is None:
             logger.warning("Template location is not configured. Skipping upload.")
             return
 
-        test_data_api: PolarionTestDataApi = GenericTestCase.create_extension_api("test-data")
-        uploader: ProjectTemplateUploader = ProjectTemplateUploader(test_data_api=test_data_api)
+        uploader: ProjectTemplateUploader = ProjectTemplateUploader(test_data_api=self.test_data_api)
         uploader.upload_template(
             template_id=self.temp_project_template_id,
             template_location=self.temp_project_template_location,
@@ -117,16 +181,19 @@ class TempProject:
 
     def tear_down(self) -> None:
         # Delete the temporary project after testing
-        admin_utility_api: PolarionAdminUtilityApi = GenericTestCase.create_extension_api("admin-utility")
-
         start_time: float = time.time()
-        response: Response = admin_utility_api.delete_project(project_id=self.temp_project_id)
+        response: Response = self.polarion_api.delete_project(self.temp_project_id)
 
-        if response.status_code == HTTPStatus.NO_CONTENT:
-            logger.info("'%s' have been deleted in %.2f seconds", self.temp_project_id, time.time() - start_time)
-        else:
+        # Project deletion is asynchronous: the endpoint returns 202 (Accepted).
+        if response.status_code != HTTPStatus.ACCEPTED:
             logger.error("Error during deletion project '%s'", self.temp_project_id)
             logger.debug("Response status: %s", response.status_code)
             logger.debug("Response headers: %s", response.headers)
             logger.debug("Response content: %s", response.content)
             sys.exit(-1)
+
+        if not self._wait_for_project(should_exist=False):
+            logger.error("Timed out waiting for project '%s' to be deleted", self.temp_project_id)
+            sys.exit(-1)
+
+        logger.info("'%s' have been deleted in %.2f seconds", self.temp_project_id, time.time() - start_time)

--- a/python_sbb_polarion/testing/temp_project.py
+++ b/python_sbb_polarion/testing/temp_project.py
@@ -7,6 +7,7 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from python_sbb_polarion.core import ExtensionApiFactory
 from python_sbb_polarion.testing.errors import TempProjectError
 from python_sbb_polarion.testing.generic_test_case import GenericTestCase
 from python_sbb_polarion.testing.project_template_uploader import ProjectTemplateUploader
@@ -75,9 +76,13 @@ class TempProject:
         self.temp_project_template_id: str = template_id
         self.temp_project_template_location: Path | None = template_location
 
-        # Build the API clients once up front; from here on they are always ready to use.
+        # Build the API clients once up front, sharing a single connection: the test-data extension
+        # client is derived from the standard API's connection instead of opening a second one.
         self.polarion_api: PolarionApiV1 = GenericTestCase.create_polarion_api()
-        self.test_data_api: PolarionTestDataApi = GenericTestCase.create_extension_api("test-data")
+        self.test_data_api: PolarionTestDataApi = ExtensionApiFactory.get_extension_api_by_name(
+            extension_name="test-data",
+            polarion_connection=self.polarion_api.polarion_connection,
+        )
 
         self._upload_project_template(transform_links)
         self._create_temp_project()
@@ -98,6 +103,10 @@ class TempProject:
         if existing_response.status_code == HTTPStatus.OK:
             logger.info("'%s' already exists... nothing to do", self.temp_project_id)
             return
+        # Anything other than "exists" (200) or "not found" (404) is an obstacle (auth, server error)
+        # that creation would not solve - surface it here with the real status instead of falling through.
+        if existing_response.status_code != HTTPStatus.NOT_FOUND:
+            self._fail("look up", existing_response)
 
         start_time: float = time.time()
         # createProject expects a flat body (not JSON:API); projectId, trackerPrefix and
@@ -166,7 +175,16 @@ class TempProject:
         logger.info("Waiting for %s job '%s' of project '%s'...", action, job_id, self.temp_project_id)
 
         for attempt in range(POLL_MAX_ATTEMPTS):
-            job_body: JsonDict = self.polarion_api.get_job(job_id).json()
+            job_response: Response = self.polarion_api.get_job(job_id)
+            # A non-200 or non-JSON poll (transient 5xx, gateway/SSO HTML page) is treated as
+            # "not ready yet" rather than crashing: we keep polling and, if it persists, time out
+            # with a clean TempProjectError instead of leaking a raw requests/JSON exception.
+            job_body: JsonDict
+            if job_response.status_code == HTTPStatus.OK:
+                job_body = self._safe_json(job_response)
+            else:
+                logger.debug("Poll of %s job '%s' returned HTTP %s; retrying", action, job_id, job_response.status_code)
+                job_body = {}
             status_type: str | None
             message: str | None
             status_type, message = self._job_status(job_body)
@@ -179,6 +197,22 @@ class TempProject:
 
         raise TempProjectError(f"Timed out waiting for {action} job '{job_id}' of project '{self.temp_project_id}'")
 
+    @staticmethod
+    def _safe_json(response: Response) -> JsonDict:
+        """Parse a response body as a JSON object, returning {} for non-JSON or non-object bodies.
+
+        Returns:
+            JsonDict: The parsed object, or an empty dict if the body is not a JSON object
+        """
+        try:
+            parsed: JsonValue = response.json()
+        except ValueError:
+            # requests raises JSONDecodeError (a ValueError subclass) for HTML/empty bodies.
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+        return {}
+
     def _job_id_from_response(self, response: Response, action: str) -> str:
         """Extract the job id from an async 202 response body (jobsSinglePostResponse).
 
@@ -188,7 +222,7 @@ class TempProject:
         Raises:
             TempProjectError: If the body has no usable job id
         """
-        body: JsonDict = response.json()
+        body: JsonDict = self._safe_json(response)
         data: JsonValue = body.get("data")
         if isinstance(data, dict):
             job_id: JsonValue = data.get("id")

--- a/python_sbb_polarion/testing/temp_project.py
+++ b/python_sbb_polarion/testing/temp_project.py
@@ -13,6 +13,8 @@ from python_sbb_polarion.testing.project_template_uploader import ProjectTemplat
 
 
 if TYPE_CHECKING:
+    from typing import NoReturn
+
     from requests import Response
 
     from python_sbb_polarion.core import PolarionApiV1
@@ -106,11 +108,7 @@ class TempProject:
 
         # Project creation is asynchronous: the endpoint returns 202 (Accepted) with a job.
         if response.status_code != HTTPStatus.ACCEPTED:
-            logger.error("Error during creation project '%s'", self.temp_project_id)
-            logger.debug("Response status: %s", response.status_code)
-            logger.debug("Response headers: %s", response.headers)
-            logger.debug("Response content: %s", response.content)
-            sys.exit(-1)
+            self._fail("creation", response)
 
         if not self._wait_for_project(should_exist=True):
             logger.error("Timed out waiting for project '%s' to become available", self.temp_project_id)
@@ -143,6 +141,13 @@ class TempProject:
                 response.status_code,
             )
 
+    def _fail(self, action: str, response: Response) -> NoReturn:
+        logger.error("Error during %s project '%s'", action, self.temp_project_id)
+        logger.debug("Response status: %s", response.status_code)
+        logger.debug("Response headers: %s", response.headers)
+        logger.debug("Response content: %s", response.content)
+        sys.exit(-1)
+
     def _wait_for_project(self, should_exist: bool) -> bool:
         """Poll the project resource until it reaches the desired presence state.
 
@@ -152,19 +157,16 @@ class TempProject:
         Returns:
             bool: True if the desired state was reached within the timeout, False otherwise
         """
-        if should_exist:
-            logger.info("Waiting for project '%s' to be created...", self.temp_project_id)
-        else:
-            logger.info("Waiting for project '%s' to be deleted...", self.temp_project_id)
+        target_status: HTTPStatus = HTTPStatus.OK if should_exist else HTTPStatus.NOT_FOUND
+        logger.info("Waiting for project '%s' to be %s...", self.temp_project_id, "created" if should_exist else "deleted")
 
-        for _ in range(POLL_MAX_ATTEMPTS):
+        for attempt in range(POLL_MAX_ATTEMPTS):
             # While polling, the transient 404/200 mismatches are expected, so suppress the client's non-2xx warning.
             response: Response = self.polarion_api.get_project(self.temp_project_id, print_error=False)
-            if should_exist and response.status_code == HTTPStatus.OK:
+            if response.status_code == target_status:
                 return True
-            if not should_exist and response.status_code == HTTPStatus.NOT_FOUND:
-                return True
-            time.sleep(POLL_INTERVAL_SECONDS)
+            if attempt < POLL_MAX_ATTEMPTS - 1:
+                time.sleep(POLL_INTERVAL_SECONDS)
         return False
 
     def _upload_project_template(self, transform_links: SparseFields | None = None) -> None:
@@ -186,11 +188,7 @@ class TempProject:
 
         # Project deletion is asynchronous: the endpoint returns 202 (Accepted).
         if response.status_code != HTTPStatus.ACCEPTED:
-            logger.error("Error during deletion project '%s'", self.temp_project_id)
-            logger.debug("Response status: %s", response.status_code)
-            logger.debug("Response headers: %s", response.headers)
-            logger.debug("Response content: %s", response.content)
-            sys.exit(-1)
+            self._fail("deletion", response)
 
         if not self._wait_for_project(should_exist=False):
             logger.error("Timed out waiting for project '%s' to be deleted", self.temp_project_id)

--- a/tests/unit/testing/test_generic_test_case.py
+++ b/tests/unit/testing/test_generic_test_case.py
@@ -70,6 +70,27 @@ class TestGenericTestCase(unittest.TestCase):
         self.assertEqual(call_kwargs["extension_name"], "admin-utility")
         mock_polarion_api_v1.assert_called_once()
 
+    @patch("python_sbb_polarion.testing.generic_test_case.PolarionApiV1")
+    @patch("python_sbb_polarion.testing.generic_test_case.get_script_arguments")
+    @patch.dict("os.environ", {"APP_URL": "https://example.com", "APP_TOKEN": "test-token"})
+    def test_create_polarion_api(self, mock_get_args: Mock, mock_polarion_api_v1: Mock) -> None:
+        """Test create_polarion_api builds a connection and returns a PolarionApiV1."""
+        # Arrange
+        mock_args = SimpleNamespace(app_url=None, app_token=None)
+        mock_get_args.return_value = mock_args
+
+        mock_api = Mock()
+        mock_polarion_api_v1.return_value = mock_api
+
+        # Act
+        result: object = GenericTestCase.create_polarion_api()
+
+        # Assert
+        self.assertEqual(result, mock_api)
+        mock_polarion_api_v1.assert_called_once()
+        call_args: tuple[object, ...] = mock_polarion_api_v1.call_args[0]
+        self.assertIsInstance(call_args[0], PolarionRestApiConnection)
+
     @patch.dict("os.environ", {"TEST_PARAM": "env_value"})
     def test_get_parameter_from_env(self) -> None:
         """Test get_parameter returns environment variable when available."""

--- a/tests/unit/testing/test_project_template_uploader.py
+++ b/tests/unit/testing/test_project_template_uploader.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+from python_sbb_polarion.testing.errors import TempProjectError
 from python_sbb_polarion.testing.project_template_uploader import ProjectTemplateUploader
 
 
@@ -86,19 +87,14 @@ class TestProjectTemplateUploader(unittest.TestCase):
             self.assertEqual(len(result), 128)
 
     def test_zip_folder_not_a_directory(self) -> None:
-        """Test zip_folder exits when path is not a directory."""
+        """Test zip_folder raises when path is not a directory."""
         with tempfile.NamedTemporaryFile(mode="wb", delete=False) as tmp_file:
             tmp_file.write(b"test")
             tmp_path: Path = Path(tmp_file.name)
 
         try:
-            with patch("python_sbb_polarion.testing.project_template_uploader.sys.exit") as mock_exit:
-                mock_exit.side_effect = SystemExit(1)
-
-                with self.assertRaises(SystemExit):
-                    ProjectTemplateUploader.zip_folder(tmp_path)
-
-                mock_exit.assert_called_once_with(1)
+            with self.assertRaises(TempProjectError):
+                ProjectTemplateUploader.zip_folder(tmp_path)
         finally:
             tmp_path.unlink()
 
@@ -132,14 +128,9 @@ class TestProjectTemplateUploader(unittest.TestCase):
                     zip_path.unlink()
 
     def test_upload_template_folder_not_exists(self) -> None:
-        """Test upload_template exits when folder doesn't exist."""
-        with patch("python_sbb_polarion.testing.project_template_uploader.sys.exit") as mock_exit:
-            mock_exit.side_effect = SystemExit(1)
-
-            with self.assertRaises(SystemExit):
-                self.uploader.upload_template("template1", Path("/non/existent/folder"))
-
-            mock_exit.assert_called_once_with(1)
+        """Test upload_template raises when folder doesn't exist."""
+        with self.assertRaises(TempProjectError):
+            self.uploader.upload_template("template1", Path("/non/existent/folder"))
 
     def test_upload_template_up_to_date(self) -> None:
         """Test upload_template skips upload when hashes match."""
@@ -229,21 +220,16 @@ class TestProjectTemplateUploader(unittest.TestCase):
             mock_save_response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
             self.mock_api.save_project_template.return_value = mock_save_response
 
-            with patch("python_sbb_polarion.testing.project_template_uploader.sys.exit") as mock_exit:
-                mock_exit.side_effect = SystemExit(1)
+            with patch.object(ProjectTemplateUploader, "zip_folder") as mock_zip:
+                mock_zip_path = Path("/tmp/test.zip")
+                mock_zip.return_value = mock_zip_path
 
-                with patch.object(ProjectTemplateUploader, "zip_folder") as mock_zip:
-                    mock_zip_path = Path("/tmp/test.zip")
-                    mock_zip.return_value = mock_zip_path
+                with patch.object(Path, "exists", return_value=True), patch.object(Path, "unlink") as mock_unlink:
+                    with self.assertRaises(TempProjectError):
+                        self.uploader.upload_template("template1", tmp_path)
 
-                    with patch.object(Path, "exists", return_value=True), patch.object(Path, "unlink") as mock_unlink:
-                        with self.assertRaises(SystemExit):
-                            self.uploader.upload_template("template1", tmp_path)
-
-                        # Verify cleanup happened even on error
-                        mock_unlink.assert_called_once()
-
-                mock_exit.assert_called_once_with(1)
+                    # Verify cleanup happened even on error
+                    mock_unlink.assert_called_once()
 
     def test_upload_template_cleanup_on_success(self) -> None:
         """Test upload_template cleans up zip file after successful upload."""

--- a/tests/unit/testing/test_temp_project.py
+++ b/tests/unit/testing/test_temp_project.py
@@ -49,10 +49,10 @@ def _success_polarion_api() -> Mock:
 class TestTempProject(unittest.TestCase):
     """Test TempProject class."""
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_init_generates_unique_project_id(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_init_generates_unique_project_id(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test __init__ generates project ID with UUID suffix."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -67,10 +67,10 @@ class TestTempProject(unittest.TestCase):
         self.assertEqual(temp_project.temp_project_name, "Test Project")
         self.assertEqual(temp_project.temp_project_template_id, "template_id")
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_init_calls_create_project_with_template(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_init_calls_create_project_with_template(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test __init__ creates the project from the template via the standard API."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -91,10 +91,10 @@ class TestTempProject(unittest.TestCase):
             }
         )
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_get_temp_project_id(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_get_temp_project_id(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test get_temp_project_id returns project ID."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -109,10 +109,10 @@ class TestTempProject(unittest.TestCase):
         # Assert
         self.assertEqual(result, "ID_st_suffix")
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_create_temp_project_success(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_create_temp_project_success(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test _create_temp_project with successful async creation (202 -> job OK)."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -130,10 +130,10 @@ class TestTempProject(unittest.TestCase):
         mock_api.get_job.assert_called_with("job-1")
         mock_api.update_project.assert_called_once()
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_create_temp_project_already_exists(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_create_temp_project_already_exists(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test _create_temp_project skips creation when the project already exists (pre-check 200)."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -150,10 +150,10 @@ class TestTempProject(unittest.TestCase):
         self.assertIsNotNone(temp_project.temp_project_id)
         mock_api.create_project.assert_not_called()
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_create_temp_project_create_error(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_create_temp_project_create_error(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test _create_temp_project raises when create returns a non-202 status."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -168,10 +168,10 @@ class TestTempProject(unittest.TestCase):
         with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id")
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_create_temp_project_job_failed(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_create_temp_project_job_failed(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test _create_temp_project raises when the creation job reports a FAILED status."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -190,11 +190,11 @@ class TestTempProject(unittest.TestCase):
         # name is never set once the job failed
         mock_api.update_project.assert_not_called()
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     @patch("python_sbb_polarion.testing.temp_project.time.sleep")
-    def test_create_temp_project_job_timeout(self, mock_sleep: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_create_temp_project_job_timeout(self, mock_sleep: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test _create_temp_project raises when the creation job never reaches a terminal status."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -211,10 +211,10 @@ class TestTempProject(unittest.TestCase):
         with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id")
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_create_temp_project_unexpected_job_body(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_create_temp_project_unexpected_job_body(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test _create_temp_project raises when the 202 response has no usable job id."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -229,10 +229,10 @@ class TestTempProject(unittest.TestCase):
         with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id")
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_create_temp_project_sets_name(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_create_temp_project_sets_name(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test _create_temp_project sets the project name via update_project after creation."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -255,10 +255,10 @@ class TestTempProject(unittest.TestCase):
         }
         mock_api.update_project.assert_called_once_with("TEST_st_uuid", expected_data)
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_create_temp_project_set_name_failure_does_not_raise(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_create_temp_project_set_name_failure_does_not_raise(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test name-setting failure is best-effort (warns, does not raise)."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -275,9 +275,9 @@ class TestTempProject(unittest.TestCase):
         self.assertIsNotNone(temp_project.temp_project_id)
         mock_api.update_project.assert_called_once()
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    def test_tear_down_success(self, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_tear_down_success(self, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test tear_down with successful async deletion (202 -> job OK)."""
         # Arrange
         mock_api: Mock = _success_polarion_api()
@@ -296,9 +296,9 @@ class TestTempProject(unittest.TestCase):
             mock_api.delete_project.assert_called_once_with("TEST_st_uuid")
             mock_api.get_job.assert_called_with("del-job")
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    def test_tear_down_delete_error(self, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_tear_down_delete_error(self, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test tear_down raises when delete returns a non-202 status."""
         # Arrange
         mock_api: Mock = _success_polarion_api()
@@ -315,10 +315,10 @@ class TestTempProject(unittest.TestCase):
             with self.assertRaises(TempProjectError):
                 temp_project.tear_down()
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.time.sleep")
-    def test_tear_down_deletion_timeout(self, mock_sleep: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_tear_down_deletion_timeout(self, mock_sleep: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test tear_down raises when the deletion job never reaches a terminal status."""
         # Arrange
         mock_api: Mock = _success_polarion_api()
@@ -338,24 +338,24 @@ class TestTempProject(unittest.TestCase):
 
     @patch("python_sbb_polarion.testing.project_template_uploader.Path.exists", return_value=False)
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_upload_project_template_file_not_exists(self, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
+    def test_upload_project_template_file_not_exists(self, mock_uuid: Mock, mock_factory: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
         """Test _upload_project_template raises when file does not exist."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
-        mock_create_extension.return_value = Mock()
+        mock_factory.return_value = Mock()
         mock_create_polarion.return_value = _success_polarion_api()
 
         # Act & Assert
         with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id", template_location=Path("/tmp/nonexistent"))
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_upload_project_template_no_location(self, mock_uuid: Mock, mock_create_polarion: Mock, mock_create_extension: Mock) -> None:
+    def test_upload_project_template_no_location(self, mock_uuid: Mock, mock_create_polarion: Mock, mock_factory: Mock) -> None:
         """Test _upload_project_template returns early when location is None."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -372,9 +372,9 @@ class TestTempProject(unittest.TestCase):
 
     @patch("python_sbb_polarion.testing.project_template_uploader.Path.exists", return_value=True)
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_upload_project_template_hash_match(self, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
+    def test_upload_project_template_hash_match(self, mock_uuid: Mock, mock_factory: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
         """Test _upload_project_template skips upload when hash matches."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -383,7 +383,7 @@ class TestTempProject(unittest.TestCase):
         test_hash: str = "abc123hash"
         mock_test_data_api = Mock()
         mock_test_data_api.get_template_hash.return_value = Mock(status_code=HTTPStatus.OK, text=test_hash)
-        mock_create_extension.return_value = mock_test_data_api
+        mock_factory.return_value = mock_test_data_api
         mock_create_polarion.return_value = _success_polarion_api()
 
         # Act
@@ -397,12 +397,12 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.project_template_uploader.ProjectTemplateUploader.zip_folder")
     @patch("python_sbb_polarion.testing.project_template_uploader.Path.exists", return_value=True)
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     def test_upload_project_template_hash_differs(
         self,
         mock_uuid: Mock,
-        mock_create_extension: Mock,
+        mock_factory: Mock,
         mock_create_polarion: Mock,
         mock_exists: Mock,
         mock_zip_folder: Mock,
@@ -420,7 +420,7 @@ class TestTempProject(unittest.TestCase):
         mock_test_data_api = Mock()
         mock_test_data_api.get_template_hash.return_value = Mock(status_code=HTTPStatus.OK, text=remote_hash)
         mock_test_data_api.save_project_template.return_value = Mock(status_code=HTTPStatus.CREATED)
-        mock_create_extension.return_value = mock_test_data_api
+        mock_factory.return_value = mock_test_data_api
         mock_create_polarion.return_value = _success_polarion_api()
 
         # Act
@@ -435,9 +435,9 @@ class TestTempProject(unittest.TestCase):
 
     @patch("python_sbb_polarion.testing.project_template_uploader.Path.exists", return_value=True)
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_upload_project_template_upload_fails(self, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
+    def test_upload_project_template_upload_fails(self, mock_uuid: Mock, mock_factory: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
         """Test _upload_project_template raises when upload fails."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -449,16 +449,16 @@ class TestTempProject(unittest.TestCase):
         mock_test_data_api = Mock()
         mock_test_data_api.get_template_hash.return_value = Mock(status_code=HTTPStatus.OK, text=remote_hash)
         mock_test_data_api.save_project_template.return_value = Mock(status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
-        mock_create_extension.return_value = mock_test_data_api
+        mock_factory.return_value = mock_test_data_api
         mock_create_polarion.return_value = _success_polarion_api()
 
         # Act & Assert
         with patch("python_sbb_polarion.testing.project_template_uploader.ProjectTemplateUploader.calculate_folder_hash", return_value=local_hash), self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id", template_location=Path("/tmp/template"))
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    def test_init_keeps_project_id_when_not_mutated(self, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_init_keeps_project_id_when_not_mutated(self, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test __init__ keeps the given project id verbatim when mutate_project_id is False."""
         # Arrange
         mock_create_api.return_value = _success_polarion_api()
@@ -469,9 +469,9 @@ class TestTempProject(unittest.TestCase):
         # Assert
         self.assertEqual(temp_project.temp_project_id, "FIXED")
 
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    def test_create_temp_project_job_id_missing(self, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+    def test_create_temp_project_job_id_missing(self, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test _create_temp_project raises when the 202 body has a data object but no job id."""
         # Arrange
         mock_api: Mock = _success_polarion_api()
@@ -492,6 +492,71 @@ class TestTempProject(unittest.TestCase):
             TempProject._job_status({"data": {"attributes": {"status": {"type": "OK", "message": "done"}}}}),
             ("OK", "done"),
         )
+
+    def test_safe_json_handles_non_object_bodies(self) -> None:
+        """Test _safe_json returns {} for non-JSON or non-object bodies, and the dict otherwise."""
+        non_json: Mock = Mock()
+        non_json.json.side_effect = ValueError("no json")
+        self.assertEqual(TempProject._safe_json(non_json), {})
+
+        as_list: Mock = Mock()
+        as_list.json.return_value = [1, 2, 3]
+        self.assertEqual(TempProject._safe_json(as_list), {})
+
+        as_object: Mock = Mock()
+        as_object.json.return_value = {"a": 1}
+        self.assertEqual(TempProject._safe_json(as_object), {"a": 1})
+
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    def test_create_temp_project_precheck_error(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
+        """Test _create_temp_project raises when the existence pre-check returns a non-200/non-404 status."""
+        # Arrange
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="precheck-uuid")
+
+        mock_api: Mock = _success_polarion_api()
+        mock_api.get_project.return_value = _response(HTTPStatus.FORBIDDEN)
+        mock_create_api.return_value = mock_api
+
+        # Act & Assert
+        with self.assertRaises(TempProjectError):
+            TempProject("TEST", "Test Project", "template_id")
+
+        # the obstacle is surfaced before any creation attempt
+        mock_api.create_project.assert_not_called()
+
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    @patch("python_sbb_polarion.testing.temp_project.time.sleep")
+    def test_wait_for_job_retries_transient_poll_errors(self, mock_sleep: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
+        """Test _wait_for_job keeps polling through a non-200 then a non-JSON response before OK."""
+        # Arrange
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="transient-uuid")
+
+        bad_json: Mock = Mock()
+        bad_json.status_code = HTTPStatus.OK
+        bad_json.json.side_effect = ValueError("html error page")
+
+        mock_api: Mock = _success_polarion_api()
+        # transient 503, then a 200 with a non-JSON body, then a finished job
+        mock_api.get_job.side_effect = [
+            _response(HTTPStatus.SERVICE_UNAVAILABLE),
+            bad_json,
+            _job("OK"),
+        ]
+        mock_create_api.return_value = mock_api
+
+        # Act - should not raise
+        temp_project = TempProject("TEST", "Test Project", "template_id")
+
+        # Assert
+        self.assertIsNotNone(temp_project.temp_project_id)
+        self.assertEqual(mock_api.get_job.call_count, 3)
+        mock_api.update_project.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/unit/testing/test_temp_project.py
+++ b/tests/unit/testing/test_temp_project.py
@@ -5,24 +5,43 @@ from __future__ import annotations
 import unittest
 from http import HTTPStatus
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 from python_sbb_polarion.testing.temp_project import TempProject
 
 
-def _response(status_code: HTTPStatus) -> Mock:
-    """Build a mock HTTP response with the given status code."""
+def _response(status_code: HTTPStatus, json_body: Any = None) -> Mock:
+    """Build a mock HTTP response with the given status code and JSON body."""
     response: Mock = Mock()
     response.status_code = status_code
+    response.json.return_value = json_body
     return response
 
 
+def _accepted_job(job_id: str = "job-1") -> Mock:
+    """Build a 202 (Accepted) response whose body carries an async job descriptor."""
+    return _response(HTTPStatus.ACCEPTED, {"data": {"type": "jobs", "id": job_id}})
+
+
+def _job(status_type: str | None, message: str | None = None) -> Mock:
+    """Build a GET /jobs/{id} response with the given terminal status type (None = still running)."""
+    status: dict[str, Any] = {}
+    if status_type is not None:
+        status["type"] = status_type
+    if message is not None:
+        status["message"] = message
+    return _response(HTTPStatus.OK, {"data": {"attributes": {"status": status}}})
+
+
 def _success_polarion_api() -> Mock:
-    """Mock PolarionApiV1 for a successful create flow (not-exists -> create 202 -> ready -> name set)."""
+    """Mock PolarionApiV1 for a successful create flow (not-exists -> create 202 -> job OK -> name set)."""
     api: Mock = Mock()
-    api.get_project.side_effect = [_response(HTTPStatus.NOT_FOUND), _response(HTTPStatus.OK)]
-    api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
+    api.get_project.return_value = _response(HTTPStatus.NOT_FOUND)
+    api.create_project.return_value = _accepted_job()
+    api.get_job.return_value = _job("OK")
     api.update_project.return_value = _response(HTTPStatus.NO_CONTENT)
+    api.delete_project.return_value = _accepted_job("del-job")
     return api
 
 
@@ -93,7 +112,7 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     def test_create_temp_project_success(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test _create_temp_project with successful async creation (202 -> ready)."""
+        """Test _create_temp_project with successful async creation (202 -> job OK)."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="uuid-suffix")
@@ -106,7 +125,8 @@ class TestTempProject(unittest.TestCase):
         # Assert
         self.assertIsNotNone(temp_project.temp_project_id)
         mock_api.create_project.assert_called_once()
-        # name is set after the project becomes available
+        # the creation job is polled, then the name is set once it finishes
+        mock_api.get_job.assert_called_with("job-1")
         mock_api.update_project.assert_called_once()
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
@@ -156,18 +176,70 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
+    def test_create_temp_project_job_failed(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project exits when the creation job reports a FAILED status."""
+        # Arrange
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="failed-uuid")
+
+        mock_api: Mock = Mock()
+        mock_api.get_project.return_value = _response(HTTPStatus.NOT_FOUND)
+        mock_api.create_project.return_value = _accepted_job()
+        mock_api.get_job.return_value = _job("FAILED", "template broken")
+        mock_create_api.return_value = mock_api
+
+        # sys.exit raises SystemExit in production; make the mock stop execution too
+        mock_exit.side_effect = SystemExit
+
+        # Act & Assert
+        with self.assertRaises(SystemExit):
+            TempProject("TEST", "Test Project", "template_id")
+
+        mock_exit.assert_called_once_with(-1)
+        # name is never set once the job failed
+        mock_api.update_project.assert_not_called()
+
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     @patch("python_sbb_polarion.testing.temp_project.time.sleep")
     @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_create_temp_project_readiness_timeout(self, mock_exit: Mock, mock_sleep: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test _create_temp_project exits when the project never becomes available."""
+    def test_create_temp_project_job_timeout(self, mock_exit: Mock, mock_sleep: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project exits when the creation job never reaches a terminal status."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="timeout-uuid")
 
         mock_api: Mock = Mock()
-        # pre-check not-exists, then never becomes ready
         mock_api.get_project.return_value = _response(HTTPStatus.NOT_FOUND)
-        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_api.create_project.return_value = _accepted_job()
+        # job stays in a non-terminal state forever
+        mock_api.get_job.return_value = _job("UNKNOWN")
+        mock_create_api.return_value = mock_api
+
+        # sys.exit raises SystemExit in production; make the mock stop execution too
+        mock_exit.side_effect = SystemExit
+
+        # Act & Assert
+        with self.assertRaises(SystemExit):
+            TempProject("TEST", "Test Project", "template_id")
+
+        mock_exit.assert_called_once_with(-1)
+
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
+    def test_create_temp_project_unexpected_job_body(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project exits when the 202 response has no usable job id."""
+        # Arrange
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="nojob-uuid")
+
+        mock_api: Mock = Mock()
+        mock_api.get_project.return_value = _response(HTTPStatus.NOT_FOUND)
+        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED, {"unexpected": True})
         mock_create_api.return_value = mock_api
 
         # sys.exit raises SystemExit in production; make the mock stop execution too
@@ -215,9 +287,7 @@ class TestTempProject(unittest.TestCase):
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="warn-uuid")
 
-        mock_api: Mock = Mock()
-        mock_api.get_project.side_effect = [_response(HTTPStatus.NOT_FOUND), _response(HTTPStatus.OK)]
-        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_api: Mock = _success_polarion_api()
         mock_api.update_project.return_value = _response(HTTPStatus.INTERNAL_SERVER_ERROR)
         mock_create_api.return_value = mock_api
 
@@ -231,18 +301,9 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     def test_tear_down_success(self, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test tear_down with successful async deletion (202 -> gone)."""
+        """Test tear_down with successful async deletion (202 -> job OK)."""
         # Arrange
-        mock_api: Mock = Mock()
-        # __init__: pre-check 404, ready 200; tear_down: gone 404
-        mock_api.get_project.side_effect = [
-            _response(HTTPStatus.NOT_FOUND),
-            _response(HTTPStatus.OK),
-            _response(HTTPStatus.NOT_FOUND),
-        ]
-        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
-        mock_api.update_project.return_value = _response(HTTPStatus.NO_CONTENT)
-        mock_api.delete_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_api: Mock = _success_polarion_api()
         mock_create_api.return_value = mock_api
 
         with patch("python_sbb_polarion.testing.temp_project.uuid.uuid4") as mock_uuid:
@@ -256,6 +317,7 @@ class TestTempProject(unittest.TestCase):
 
             # Assert
             mock_api.delete_project.assert_called_once_with("TEST_st_uuid")
+            mock_api.get_job.assert_called_with("del-job")
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
@@ -263,10 +325,7 @@ class TestTempProject(unittest.TestCase):
     def test_tear_down_delete_error(self, mock_exit: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
         """Test tear_down error handling when delete returns a non-202 status."""
         # Arrange
-        mock_api: Mock = Mock()
-        mock_api.get_project.side_effect = [_response(HTTPStatus.NOT_FOUND), _response(HTTPStatus.OK)]
-        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
-        mock_api.update_project.return_value = _response(HTTPStatus.NO_CONTENT)
+        mock_api: Mock = _success_polarion_api()
         mock_api.delete_project.return_value = _response(HTTPStatus.INTERNAL_SERVER_ERROR)
         mock_create_api.return_value = mock_api
 
@@ -290,17 +349,11 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.time.sleep")
     @patch("python_sbb_polarion.testing.temp_project.sys.exit")
     def test_tear_down_deletion_timeout(self, mock_exit: Mock, mock_sleep: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test tear_down exits when the project is never removed."""
+        """Test tear_down exits when the deletion job never reaches a terminal status."""
         # Arrange
-        mock_api: Mock = Mock()
-        # __init__: pre-check 404, ready 200; tear_down poll: always 200 (never gone)
-        mock_api.get_project.side_effect = [
-            _response(HTTPStatus.NOT_FOUND),
-            *[_response(HTTPStatus.OK) for _ in range(200)],
-        ]
-        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
-        mock_api.update_project.return_value = _response(HTTPStatus.NO_CONTENT)
-        mock_api.delete_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_api: Mock = _success_polarion_api()
+        # creation job finishes (OK), deletion job never reaches a terminal status
+        mock_api.get_job.side_effect = [_job("OK"), *[_job("UNKNOWN") for _ in range(200)]]
         mock_create_api.return_value = mock_api
 
         with patch("python_sbb_polarion.testing.temp_project.uuid.uuid4") as mock_uuid:
@@ -450,6 +503,49 @@ class TestTempProject(unittest.TestCase):
                 TempProject("TEST", "Test Project", "template_id", template_location=Path("/tmp/template"))
 
             mock_exit.assert_called_with(1)
+
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    def test_init_keeps_project_id_when_not_mutated(self, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test __init__ keeps the given project id verbatim when mutate_project_id is False."""
+        # Arrange
+        mock_create_api.return_value = _success_polarion_api()
+
+        # Act
+        temp_project = TempProject("FIXED", "Test Project", "template_id", mutate_project_id=False)
+
+        # Assert
+        self.assertEqual(temp_project.temp_project_id, "FIXED")
+
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
+    def test_create_temp_project_job_id_missing(self, mock_exit: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project exits when the 202 body has a data object but no job id."""
+        # Arrange
+        mock_api: Mock = _success_polarion_api()
+        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED, {"data": {"type": "jobs"}})
+        mock_create_api.return_value = mock_api
+
+        # sys.exit raises SystemExit in production; make the mock stop execution too
+        mock_exit.side_effect = SystemExit
+
+        # Act & Assert
+        with self.assertRaises(SystemExit):
+            TempProject("TEST", "Test Project", "template_id", mutate_project_id=False)
+
+        mock_exit.assert_called_once_with(-1)
+
+    def test_job_status_handles_malformed_bodies(self) -> None:
+        """Test _job_status returns (None, None) for bodies without a terminal status object."""
+        self.assertEqual(TempProject._job_status({}), (None, None))
+        self.assertEqual(TempProject._job_status({"data": "not-a-dict"}), (None, None))
+        self.assertEqual(TempProject._job_status({"data": {"attributes": "nope"}}), (None, None))
+        self.assertEqual(TempProject._job_status({"data": {"attributes": {"status": "nope"}}}), (None, None))
+        self.assertEqual(
+            TempProject._job_status({"data": {"attributes": {"status": {"type": "OK", "message": "done"}}}}),
+            ("OK", "done"),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/testing/test_temp_project.py
+++ b/tests/unit/testing/test_temp_project.py
@@ -8,27 +8,36 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from python_sbb_polarion.testing.temp_project import TempProject
-from python_sbb_polarion.types import Header, MediaType
+
+
+def _response(status_code: HTTPStatus) -> Mock:
+    """Build a mock HTTP response with the given status code."""
+    response: Mock = Mock()
+    response.status_code = status_code
+    return response
+
+
+def _success_polarion_api() -> Mock:
+    """Mock PolarionApiV1 for a successful create flow (not-exists -> create 202 -> ready -> name set)."""
+    api: Mock = Mock()
+    api.get_project.side_effect = [_response(HTTPStatus.NOT_FOUND), _response(HTTPStatus.OK)]
+    api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
+    api.update_project.return_value = _response(HTTPStatus.NO_CONTENT)
+    return api
 
 
 class TestTempProject(unittest.TestCase):
     """Test TempProject class."""
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_init_generates_unique_project_id(self, mock_uuid: Mock, mock_create_api: Mock) -> None:
+    def test_init_generates_unique_project_id(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
         """Test __init__ generates project ID with UUID suffix."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="12345678-1234-1234-1234-123456789abc")
-
-        mock_response = Mock()
-        mock_response.status_code = HTTPStatus.OK
-        mock_response.text = "Success"
-
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_response
-        mock_create_api.return_value = mock_admin_api
+        mock_create_api.return_value = _success_polarion_api()
 
         # Act
         temp_project = TempProject("TEST", "Test Project", "template_id")
@@ -39,195 +48,260 @@ class TestTempProject(unittest.TestCase):
         self.assertEqual(temp_project.temp_project_template_id, "template_id")
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_init_calls_create_temp_project(self, mock_uuid: Mock, mock_create_api: Mock) -> None:
-        """Test __init__ calls _create_temp_project."""
+    def test_init_calls_create_project_with_template(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test __init__ creates the project from the template via the standard API."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="uuid-suffix")
-
-        mock_response = Mock()
-        mock_response.status_code = HTTPStatus.OK
-
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_response
-        mock_create_api.return_value = mock_admin_api
+        mock_api: Mock = _success_polarion_api()
+        mock_create_api.return_value = mock_api
 
         # Act
         _temp_project = TempProject("PROJ", "Project Name", "template")
 
         # Assert
-        mock_admin_api.create_project.assert_called_once_with(project_id="PROJ_st_suffix", project_name="Project Name", template_id="template")
-
-    def test_get_temp_project_id(self) -> None:
-        """Test get_temp_project_id returns project ID."""
-        # Arrange
-        with patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api") as mock_create_api, patch("python_sbb_polarion.testing.temp_project.uuid.uuid4") as mock_uuid:
-            mock_uuid.return_value = Mock()
-            mock_uuid.return_value.__str__ = Mock(return_value="test-uuid-suffix")
-
-            mock_response = Mock()
-            mock_response.status_code = HTTPStatus.OK
-
-            mock_admin_api = Mock()
-            mock_admin_api.create_project.return_value = mock_response
-            mock_create_api.return_value = mock_admin_api
-
-            temp_project = TempProject("ID", "Name", "template")
-
-            # Act
-            result: str = temp_project.get_temp_project_id()
-
-            # Assert
-            self.assertEqual(result, "ID_st_suffix")
+        mock_api.create_project.assert_called_once_with(
+            {
+                "projectId": "PROJ_st_suffix",
+                "trackerPrefix": "PROJ_st_suffix",
+                "location": "PROJ_st_suffix",
+                "templateId": "template",
+            }
+        )
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    @patch("python_sbb_polarion.testing.temp_project.time.time")
-    def test_create_temp_project_success(self, mock_time: Mock, mock_uuid: Mock, mock_create_api: Mock) -> None:
-        """Test _create_temp_project with successful creation (200)."""
+    def test_get_temp_project_id(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test get_temp_project_id returns project ID."""
         # Arrange
-        mock_time.return_value = 1000.0
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="test-uuid-suffix")
+        mock_create_api.return_value = _success_polarion_api()
+
+        temp_project = TempProject("ID", "Name", "template")
+
+        # Act
+        result: str = temp_project.get_temp_project_id()
+
+        # Assert
+        self.assertEqual(result, "ID_st_suffix")
+
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    def test_create_temp_project_success(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project with successful async creation (202 -> ready)."""
+        # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="uuid-suffix")
-
-        mock_response = Mock()
-        mock_response.status_code = HTTPStatus.OK
-        mock_response.text = "Project created"
-
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_response
-        mock_create_api.return_value = mock_admin_api
+        mock_api: Mock = _success_polarion_api()
+        mock_create_api.return_value = mock_api
 
         # Act
         temp_project = TempProject("TEST", "Test Project", "template_id")
 
         # Assert
         self.assertIsNotNone(temp_project.temp_project_id)
-        mock_admin_api.create_project.assert_called_once()
+        mock_api.create_project.assert_called_once()
+        # name is set after the project becomes available
+        mock_api.update_project.assert_called_once()
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_create_temp_project_already_exists(self, mock_uuid: Mock, mock_create_api: Mock) -> None:
-        """Test _create_temp_project when project already exists (400)."""
+    def test_create_temp_project_already_exists(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project skips creation when the project already exists (pre-check 200)."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="existing-uuid")
 
-        mock_response = Mock()
-        mock_response.status_code = HTTPStatus.BAD_REQUEST
-        # UUID is "existing-uuid", split gives ["existing", "uuid"], [-1] gives "uuid"
-        mock_response.text = "Project id 'TEST_st_uuid' clashes with existing project id 'TEST_st_uuid'."
+        mock_api: Mock = Mock()
+        mock_api.get_project.return_value = _response(HTTPStatus.OK)
+        mock_create_api.return_value = mock_api
 
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_response
-        mock_create_api.return_value = mock_admin_api
-
-        # Act - should not raise exception
+        # Act - should not raise and should not attempt creation
         temp_project = TempProject("TEST", "Test Project", "template_id")
 
         # Assert
         self.assertIsNotNone(temp_project.temp_project_id)
+        mock_api.create_project.assert_not_called()
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_create_temp_project_error(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock) -> None:
-        """Test _create_temp_project error handling with sys.exit."""
+    def test_create_temp_project_create_error(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project error handling when create returns a non-202 status."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="error-uuid")
 
-        mock_response = Mock()
-        mock_response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
-        mock_response.text = "Internal Server Error"
-        mock_response.headers = {Header.CONTENT_TYPE: MediaType.JSON}
-        mock_response.content = b"Error content"
+        mock_api: Mock = Mock()
+        mock_api.get_project.return_value = _response(HTTPStatus.NOT_FOUND)
+        mock_api.create_project.return_value = _response(HTTPStatus.INTERNAL_SERVER_ERROR)
+        mock_create_api.return_value = mock_api
 
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_response
-        mock_create_api.return_value = mock_admin_api
+        # sys.exit raises SystemExit in production; make the mock stop execution too
+        mock_exit.side_effect = SystemExit
 
-        # Act
-        TempProject("TEST", "Test Project", "template_id")
+        # Act & Assert
+        with self.assertRaises(SystemExit):
+            TempProject("TEST", "Test Project", "template_id")
 
-        # Assert
         mock_exit.assert_called_once_with(-1)
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_create_temp_project_400_different_error(self, mock_uuid: Mock, mock_create_api: Mock) -> None:
-        """Test _create_temp_project with 400 status but different error message."""
+    @patch("python_sbb_polarion.testing.temp_project.time.sleep")
+    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
+    def test_create_temp_project_readiness_timeout(self, mock_exit: Mock, mock_sleep: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project exits when the project never becomes available."""
         # Arrange
         mock_uuid.return_value = Mock()
-        mock_uuid.return_value.__str__ = Mock(return_value="error-uuid")
+        mock_uuid.return_value.__str__ = Mock(return_value="timeout-uuid")
 
-        mock_response = Mock()
-        mock_response.status_code = HTTPStatus.BAD_REQUEST
-        mock_response.text = "Different error message"
-        mock_response.headers = {Header.CONTENT_TYPE: MediaType.JSON}
-        mock_response.content = b"Error content"
+        mock_api: Mock = Mock()
+        # pre-check not-exists, then never becomes ready
+        mock_api.get_project.return_value = _response(HTTPStatus.NOT_FOUND)
+        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_create_api.return_value = mock_api
 
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_response
-        mock_create_api.return_value = mock_admin_api
+        # sys.exit raises SystemExit in production; make the mock stop execution too
+        mock_exit.side_effect = SystemExit
 
         # Act & Assert
-        with patch("python_sbb_polarion.testing.temp_project.sys.exit") as mock_exit:
+        with self.assertRaises(SystemExit):
             TempProject("TEST", "Test Project", "template_id")
+
+        mock_exit.assert_called_once_with(-1)
+
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    def test_create_temp_project_sets_name(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project sets the project name via update_project after creation."""
+        # Arrange
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="name-uuid")
+        mock_api: Mock = _success_polarion_api()
+        mock_create_api.return_value = mock_api
+
+        # Act
+        TempProject("TEST", "My Project", "template_id")
+
+        # Assert
+        expected_data: dict[str, object] = {
+            "data": {
+                "type": "projects",
+                "id": "TEST_st_uuid",
+                "attributes": {
+                    "name": "My Project",
+                },
+            },
+        }
+        mock_api.update_project.assert_called_once_with("TEST_st_uuid", expected_data)
+
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
+    def test_create_temp_project_set_name_failure_does_not_exit(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test name-setting failure is best-effort (warns, does not exit)."""
+        # Arrange
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="warn-uuid")
+
+        mock_api: Mock = Mock()
+        mock_api.get_project.side_effect = [_response(HTTPStatus.NOT_FOUND), _response(HTTPStatus.OK)]
+        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_api.update_project.return_value = _response(HTTPStatus.INTERNAL_SERVER_ERROR)
+        mock_create_api.return_value = mock_api
+
+        # Act
+        temp_project = TempProject("TEST", "Test Project", "template_id")
+
+        # Assert - project created, name update failed but no exit
+        self.assertIsNotNone(temp_project.temp_project_id)
+        mock_exit.assert_not_called()
+
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    def test_tear_down_success(self, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test tear_down with successful async deletion (202 -> gone)."""
+        # Arrange
+        mock_api: Mock = Mock()
+        # __init__: pre-check 404, ready 200; tear_down: gone 404
+        mock_api.get_project.side_effect = [
+            _response(HTTPStatus.NOT_FOUND),
+            _response(HTTPStatus.OK),
+            _response(HTTPStatus.NOT_FOUND),
+        ]
+        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_api.update_project.return_value = _response(HTTPStatus.NO_CONTENT)
+        mock_api.delete_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_create_api.return_value = mock_api
+
+        with patch("python_sbb_polarion.testing.temp_project.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value = Mock()
+            mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
+
+            temp_project = TempProject("TEST", "Test Project", "template_id")
+
+            # Act
+            temp_project.tear_down()
+
+            # Assert
+            mock_api.delete_project.assert_called_once_with("TEST_st_uuid")
+
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
+    def test_tear_down_delete_error(self, mock_exit: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test tear_down error handling when delete returns a non-202 status."""
+        # Arrange
+        mock_api: Mock = Mock()
+        mock_api.get_project.side_effect = [_response(HTTPStatus.NOT_FOUND), _response(HTTPStatus.OK)]
+        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_api.update_project.return_value = _response(HTTPStatus.NO_CONTENT)
+        mock_api.delete_project.return_value = _response(HTTPStatus.INTERNAL_SERVER_ERROR)
+        mock_create_api.return_value = mock_api
+
+        with patch("python_sbb_polarion.testing.temp_project.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value = Mock()
+            mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
+
+            temp_project = TempProject("TEST", "Test Project", "template_id")
+
+            # sys.exit raises SystemExit in production; make the mock stop execution too
+            mock_exit.side_effect = SystemExit
+
+            # Act & Assert
+            with self.assertRaises(SystemExit):
+                temp_project.tear_down()
+
             mock_exit.assert_called_once_with(-1)
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
-    @patch("python_sbb_polarion.testing.temp_project.time.time")
-    def test_tear_down_success(self, mock_time: Mock, mock_create_api: Mock) -> None:
-        """Test tear_down with successful deletion (204)."""
-        # Arrange
-        mock_time.return_value = 1000.0
-
-        # Setup for __init__
-        mock_create_response = Mock()
-        mock_create_response.status_code = HTTPStatus.OK
-
-        # Setup for tear_down
-        mock_delete_response = Mock()
-        mock_delete_response.status_code = HTTPStatus.NO_CONTENT
-
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_create_response
-        mock_admin_api.delete_project.return_value = mock_delete_response
-        mock_create_api.return_value = mock_admin_api
-
-        with patch("python_sbb_polarion.testing.temp_project.uuid.uuid4") as mock_uuid:
-            mock_uuid.return_value = Mock()
-            mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
-
-            temp_project = TempProject("TEST", "Test Project", "template_id")
-
-            # Act
-            temp_project.tear_down()
-
-            # Assert
-            mock_admin_api.delete_project.assert_called_once_with(project_id="TEST_st_uuid")
-
-    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.time.sleep")
     @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_tear_down_error(self, mock_exit: Mock, mock_create_api: Mock) -> None:
-        """Test tear_down error handling with sys.exit."""
+    def test_tear_down_deletion_timeout(self, mock_exit: Mock, mock_sleep: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test tear_down exits when the project is never removed."""
         # Arrange
-        # Setup for __init__
-        mock_create_response = Mock()
-        mock_create_response.status_code = HTTPStatus.OK
-
-        # Setup for tear_down
-        mock_delete_response = Mock()
-        mock_delete_response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
-        mock_delete_response.headers = {Header.CONTENT_TYPE: MediaType.JSON}
-        mock_delete_response.content = b"Error content"
-
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_create_response
-        mock_admin_api.delete_project.return_value = mock_delete_response
-        mock_create_api.return_value = mock_admin_api
+        mock_api: Mock = Mock()
+        # __init__: pre-check 404, ready 200; tear_down poll: always 200 (never gone)
+        mock_api.get_project.side_effect = [
+            _response(HTTPStatus.NOT_FOUND),
+            *[_response(HTTPStatus.OK) for _ in range(200)],
+        ]
+        mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_api.update_project.return_value = _response(HTTPStatus.NO_CONTENT)
+        mock_api.delete_project.return_value = _response(HTTPStatus.ACCEPTED)
+        mock_create_api.return_value = mock_api
 
         with patch("python_sbb_polarion.testing.temp_project.uuid.uuid4") as mock_uuid:
             mock_uuid.return_value = Mock()
@@ -235,24 +309,27 @@ class TestTempProject(unittest.TestCase):
 
             temp_project = TempProject("TEST", "Test Project", "template_id")
 
-            # Act
-            temp_project.tear_down()
+            # sys.exit raises SystemExit in production; make the mock stop execution too
+            mock_exit.side_effect = SystemExit
 
-            # Assert
+            # Act & Assert
+            with self.assertRaises(SystemExit):
+                temp_project.tear_down()
+
             mock_exit.assert_called_once_with(-1)
 
     @patch("python_sbb_polarion.testing.project_template_uploader.Path.exists", return_value=False)
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     @patch("python_sbb_polarion.testing.project_template_uploader.sys.exit")
-    def test_upload_project_template_file_not_exists(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_exists: Mock) -> None:
+    def test_upload_project_template_file_not_exists(self, mock_exit: Mock, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
         """Test _upload_project_template exits when file does not exist."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
-
-        mock_admin_api = Mock()
-        mock_create_api.return_value = mock_admin_api
+        mock_create_extension.return_value = Mock()
+        mock_create_polarion.return_value = _success_polarion_api()
 
         # Make sys.exit raise SystemExit to stop execution
         mock_exit.side_effect = SystemExit
@@ -264,52 +341,38 @@ class TestTempProject(unittest.TestCase):
         mock_exit.assert_called_with(1)
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_upload_project_template_no_location(self, mock_uuid: Mock, mock_create_api: Mock) -> None:
+    def test_upload_project_template_no_location(self, mock_uuid: Mock, mock_create_polarion: Mock, mock_create_extension: Mock) -> None:
         """Test _upload_project_template returns early when location is None."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
-
-        mock_response = Mock()
-        mock_response.status_code = HTTPStatus.OK
-
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_response
-        mock_create_api.return_value = mock_admin_api
+        mock_api: Mock = _success_polarion_api()
+        mock_create_polarion.return_value = mock_api
 
         # Act - template_location defaults to None
         temp_project = TempProject("TEST", "Test Project", "template_id")
 
         # Assert - should not crash, project should be created
         self.assertIsNotNone(temp_project.temp_project_id)
-        mock_admin_api.create_project.assert_called_once()
+        mock_api.create_project.assert_called_once()
 
     @patch("python_sbb_polarion.testing.project_template_uploader.Path.exists", return_value=True)
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    def test_upload_project_template_hash_match(self, mock_uuid: Mock, mock_create_api: Mock, mock_exists: Mock) -> None:
+    def test_upload_project_template_hash_match(self, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
         """Test _upload_project_template skips upload when hash matches."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
 
-        mock_response = Mock()
-        mock_response.status_code = HTTPStatus.OK
-
         test_hash: str = "abc123hash"
         mock_test_data_api = Mock()
         mock_test_data_api.get_template_hash.return_value = Mock(status_code=HTTPStatus.OK, text=test_hash)
-
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_response
-
-        def create_api_side_effect(extension_name: str) -> Mock:
-            if extension_name == "test-data":
-                return mock_test_data_api
-            return mock_admin_api
-
-        mock_create_api.side_effect = create_api_side_effect
+        mock_create_extension.return_value = mock_test_data_api
+        mock_create_polarion.return_value = _success_polarion_api()
 
         # Act
         with patch("python_sbb_polarion.testing.project_template_uploader.ProjectTemplateUploader.calculate_folder_hash", return_value=test_hash):
@@ -321,22 +384,21 @@ class TestTempProject(unittest.TestCase):
 
     @patch("python_sbb_polarion.testing.project_template_uploader.ProjectTemplateUploader.zip_folder")
     @patch("python_sbb_polarion.testing.project_template_uploader.Path.exists", return_value=True)
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     def test_upload_project_template_hash_differs(
         self,
         mock_uuid: Mock,
-        mock_create_api: Mock,
+        mock_create_extension: Mock,
+        mock_create_polarion: Mock,
         mock_exists: Mock,
-        mock_zip_folder: Mock,  # This parameter name matches the decorator
+        mock_zip_folder: Mock,
     ) -> None:
         """Test _upload_project_template uploads when hash differs."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
-
-        mock_response = Mock()
-        mock_response.status_code = HTTPStatus.OK
 
         # Configure zip_folder mock to return a fake zip path
         mock_zip_folder.return_value = Path("/tmp/fake_template.zip")
@@ -346,16 +408,8 @@ class TestTempProject(unittest.TestCase):
         mock_test_data_api = Mock()
         mock_test_data_api.get_template_hash.return_value = Mock(status_code=HTTPStatus.OK, text=remote_hash)
         mock_test_data_api.save_project_template.return_value = Mock(status_code=HTTPStatus.CREATED)
-
-        mock_admin_api = Mock()
-        mock_admin_api.create_project.return_value = mock_response
-
-        def create_api_side_effect(extension_name: str) -> Mock:
-            if extension_name == "test-data":
-                return mock_test_data_api
-            return mock_admin_api
-
-        mock_create_api.side_effect = create_api_side_effect
+        mock_create_extension.return_value = mock_test_data_api
+        mock_create_polarion.return_value = _success_polarion_api()
 
         # Act
         with patch("python_sbb_polarion.testing.project_template_uploader.ProjectTemplateUploader.calculate_folder_hash", return_value=local_hash), patch.object(Path, "exists", return_value=True), patch.object(Path, "unlink"):
@@ -365,12 +419,14 @@ class TestTempProject(unittest.TestCase):
         mock_test_data_api.get_template_hash.assert_called_once_with(template_id="template_id")
         mock_test_data_api.save_project_template.assert_called_once()
         mock_zip_folder.assert_called_once_with(Path("/tmp/template"))
+        self.assertIsNotNone(temp_project.temp_project_id)
 
     @patch("python_sbb_polarion.testing.project_template_uploader.Path.exists", return_value=True)
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     @patch("python_sbb_polarion.testing.project_template_uploader.sys.exit")
-    def test_upload_project_template_upload_fails(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_exists: Mock) -> None:
+    def test_upload_project_template_upload_fails(self, mock_exit: Mock, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
         """Test _upload_project_template exits when upload fails."""
         # Arrange
         mock_uuid.return_value = Mock()
@@ -382,8 +438,8 @@ class TestTempProject(unittest.TestCase):
         mock_test_data_api = Mock()
         mock_test_data_api.get_template_hash.return_value = Mock(status_code=HTTPStatus.OK, text=remote_hash)
         mock_test_data_api.save_project_template.return_value = Mock(status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
-
-        mock_create_api.return_value = mock_test_data_api
+        mock_create_extension.return_value = mock_test_data_api
+        mock_create_polarion.return_value = _success_polarion_api()
 
         # Make sys.exit raise SystemExit to stop execution
         mock_exit.side_effect = SystemExit

--- a/tests/unit/testing/test_temp_project.py
+++ b/tests/unit/testing/test_temp_project.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
 
+from python_sbb_polarion.testing.errors import TempProjectError
 from python_sbb_polarion.testing.temp_project import TempProject
 
 
@@ -152,9 +153,8 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_create_temp_project_create_error(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test _create_temp_project error handling when create returns a non-202 status."""
+    def test_create_temp_project_create_error(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project raises when create returns a non-202 status."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="error-uuid")
@@ -164,21 +164,15 @@ class TestTempProject(unittest.TestCase):
         mock_api.create_project.return_value = _response(HTTPStatus.INTERNAL_SERVER_ERROR)
         mock_create_api.return_value = mock_api
 
-        # sys.exit raises SystemExit in production; make the mock stop execution too
-        mock_exit.side_effect = SystemExit
-
         # Act & Assert
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id")
-
-        mock_exit.assert_called_once_with(-1)
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_create_temp_project_job_failed(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test _create_temp_project exits when the creation job reports a FAILED status."""
+    def test_create_temp_project_job_failed(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project raises when the creation job reports a FAILED status."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="failed-uuid")
@@ -189,14 +183,10 @@ class TestTempProject(unittest.TestCase):
         mock_api.get_job.return_value = _job("FAILED", "template broken")
         mock_create_api.return_value = mock_api
 
-        # sys.exit raises SystemExit in production; make the mock stop execution too
-        mock_exit.side_effect = SystemExit
-
         # Act & Assert
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id")
 
-        mock_exit.assert_called_once_with(-1)
         # name is never set once the job failed
         mock_api.update_project.assert_not_called()
 
@@ -204,9 +194,8 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     @patch("python_sbb_polarion.testing.temp_project.time.sleep")
-    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_create_temp_project_job_timeout(self, mock_exit: Mock, mock_sleep: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test _create_temp_project exits when the creation job never reaches a terminal status."""
+    def test_create_temp_project_job_timeout(self, mock_sleep: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project raises when the creation job never reaches a terminal status."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="timeout-uuid")
@@ -218,21 +207,15 @@ class TestTempProject(unittest.TestCase):
         mock_api.get_job.return_value = _job("UNKNOWN")
         mock_create_api.return_value = mock_api
 
-        # sys.exit raises SystemExit in production; make the mock stop execution too
-        mock_exit.side_effect = SystemExit
-
         # Act & Assert
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id")
-
-        mock_exit.assert_called_once_with(-1)
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_create_temp_project_unexpected_job_body(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test _create_temp_project exits when the 202 response has no usable job id."""
+    def test_create_temp_project_unexpected_job_body(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project raises when the 202 response has no usable job id."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="nojob-uuid")
@@ -242,14 +225,9 @@ class TestTempProject(unittest.TestCase):
         mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED, {"unexpected": True})
         mock_create_api.return_value = mock_api
 
-        # sys.exit raises SystemExit in production; make the mock stop execution too
-        mock_exit.side_effect = SystemExit
-
         # Act & Assert
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id")
-
-        mock_exit.assert_called_once_with(-1)
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
@@ -280,9 +258,8 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_create_temp_project_set_name_failure_does_not_exit(self, mock_exit: Mock, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test name-setting failure is best-effort (warns, does not exit)."""
+    def test_create_temp_project_set_name_failure_does_not_raise(self, mock_uuid: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test name-setting failure is best-effort (warns, does not raise)."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="warn-uuid")
@@ -291,12 +268,12 @@ class TestTempProject(unittest.TestCase):
         mock_api.update_project.return_value = _response(HTTPStatus.INTERNAL_SERVER_ERROR)
         mock_create_api.return_value = mock_api
 
-        # Act
+        # Act - project is created, name update fails but is swallowed
         temp_project = TempProject("TEST", "Test Project", "template_id")
 
-        # Assert - project created, name update failed but no exit
+        # Assert
         self.assertIsNotNone(temp_project.temp_project_id)
-        mock_exit.assert_not_called()
+        mock_api.update_project.assert_called_once()
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
@@ -321,9 +298,8 @@ class TestTempProject(unittest.TestCase):
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_tear_down_delete_error(self, mock_exit: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test tear_down error handling when delete returns a non-202 status."""
+    def test_tear_down_delete_error(self, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test tear_down raises when delete returns a non-202 status."""
         # Arrange
         mock_api: Mock = _success_polarion_api()
         mock_api.delete_project.return_value = _response(HTTPStatus.INTERNAL_SERVER_ERROR)
@@ -335,21 +311,15 @@ class TestTempProject(unittest.TestCase):
 
             temp_project = TempProject("TEST", "Test Project", "template_id")
 
-            # sys.exit raises SystemExit in production; make the mock stop execution too
-            mock_exit.side_effect = SystemExit
-
             # Act & Assert
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(TempProjectError):
                 temp_project.tear_down()
-
-            mock_exit.assert_called_once_with(-1)
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.time.sleep")
-    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_tear_down_deletion_timeout(self, mock_exit: Mock, mock_sleep: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test tear_down exits when the deletion job never reaches a terminal status."""
+    def test_tear_down_deletion_timeout(self, mock_sleep: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test tear_down raises when the deletion job never reaches a terminal status."""
         # Arrange
         mock_api: Mock = _success_polarion_api()
         # creation job finishes (OK), deletion job never reaches a terminal status
@@ -362,36 +332,25 @@ class TestTempProject(unittest.TestCase):
 
             temp_project = TempProject("TEST", "Test Project", "template_id")
 
-            # sys.exit raises SystemExit in production; make the mock stop execution too
-            mock_exit.side_effect = SystemExit
-
             # Act & Assert
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(TempProjectError):
                 temp_project.tear_down()
-
-            mock_exit.assert_called_once_with(-1)
 
     @patch("python_sbb_polarion.testing.project_template_uploader.Path.exists", return_value=False)
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    @patch("python_sbb_polarion.testing.project_template_uploader.sys.exit")
-    def test_upload_project_template_file_not_exists(self, mock_exit: Mock, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
-        """Test _upload_project_template exits when file does not exist."""
+    def test_upload_project_template_file_not_exists(self, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
+        """Test _upload_project_template raises when file does not exist."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
         mock_create_extension.return_value = Mock()
         mock_create_polarion.return_value = _success_polarion_api()
 
-        # Make sys.exit raise SystemExit to stop execution
-        mock_exit.side_effect = SystemExit
-
         # Act & Assert
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id", template_location=Path("/tmp/nonexistent"))
-
-        mock_exit.assert_called_with(1)
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
@@ -478,9 +437,8 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
-    @patch("python_sbb_polarion.testing.project_template_uploader.sys.exit")
-    def test_upload_project_template_upload_fails(self, mock_exit: Mock, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
-        """Test _upload_project_template exits when upload fails."""
+    def test_upload_project_template_upload_fails(self, mock_uuid: Mock, mock_create_extension: Mock, mock_create_polarion: Mock, mock_exists: Mock) -> None:
+        """Test _upload_project_template raises when upload fails."""
         # Arrange
         mock_uuid.return_value = Mock()
         mock_uuid.return_value.__str__ = Mock(return_value="test-uuid")
@@ -494,15 +452,9 @@ class TestTempProject(unittest.TestCase):
         mock_create_extension.return_value = mock_test_data_api
         mock_create_polarion.return_value = _success_polarion_api()
 
-        # Make sys.exit raise SystemExit to stop execution
-        mock_exit.side_effect = SystemExit
-
         # Act & Assert
-        with patch("python_sbb_polarion.testing.project_template_uploader.ProjectTemplateUploader.calculate_folder_hash", return_value=local_hash):
-            with self.assertRaises(SystemExit):
-                TempProject("TEST", "Test Project", "template_id", template_location=Path("/tmp/template"))
-
-            mock_exit.assert_called_with(1)
+        with patch("python_sbb_polarion.testing.project_template_uploader.ProjectTemplateUploader.calculate_folder_hash", return_value=local_hash), self.assertRaises(TempProjectError):
+            TempProject("TEST", "Test Project", "template_id", template_location=Path("/tmp/template"))
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
@@ -519,22 +471,16 @@ class TestTempProject(unittest.TestCase):
 
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_extension_api")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
-    @patch("python_sbb_polarion.testing.temp_project.sys.exit")
-    def test_create_temp_project_job_id_missing(self, mock_exit: Mock, mock_create_api: Mock, mock_create_extension: Mock) -> None:
-        """Test _create_temp_project exits when the 202 body has a data object but no job id."""
+    def test_create_temp_project_job_id_missing(self, mock_create_api: Mock, mock_create_extension: Mock) -> None:
+        """Test _create_temp_project raises when the 202 body has a data object but no job id."""
         # Arrange
         mock_api: Mock = _success_polarion_api()
         mock_api.create_project.return_value = _response(HTTPStatus.ACCEPTED, {"data": {"type": "jobs"}})
         mock_create_api.return_value = mock_api
 
-        # sys.exit raises SystemExit in production; make the mock stop execution too
-        mock_exit.side_effect = SystemExit
-
         # Act & Assert
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(TempProjectError):
             TempProject("TEST", "Test Project", "template_id", mutate_project_id=False)
-
-        mock_exit.assert_called_once_with(-1)
 
     def test_job_status_handles_malformed_bodies(self) -> None:
         """Test _job_status returns (None, None) for bodies without a terminal status object."""


### PR DESCRIPTION
### Proposed changes

This pull request introduces several improvements to error handling, API usage, and test utilities in the Polarion system testing helpers. The main focus is on replacing abrupt process termination (`sys.exit`) with custom exceptions for better test isolation, refactoring temporary project creation/deletion to use the standard REST API (with proper async job handling), and enhancing test helper APIs for easier and more robust use.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
