### PR TITLE
feat!: deprecate admin utility methods in favor of standard Polarion API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -874,7 +874,7 @@ def get_project(self, project_id: str) -> Response:
     ...
 ```
 
-The `admin-utility` client (`PolarionAdminUtilityApi`) deprecates 16 methods this way (project/collection/document/custom-field/live-report duplicates) — see the migration table in `README.md`. When a convenience method delegates to deprecated public methods, suppress the inner warning with `warnings.catch_warnings()` so callers see exactly one warning (see `set_custom_field_type`).
+The `admin-utility` client (`PolarionAdminUtilityApi`) deprecates 16 methods this way (project/collection/document/custom-field/live-report duplicates) — see the migration table in `README.md`. A deprecated convenience method should issue its HTTP request directly rather than delegating to other deprecated methods, so callers see exactly one `DeprecationWarning` without the thread-unsafe `warnings.catch_warnings()` (warnings filter state is global before Python 3.12) — see `set_custom_field_type`.
 
 ### Extensions Module (`python_sbb_polarion/extensions/`)
 Client interfaces for SBB Polarion extensions. Each module corresponds to a specific extension from:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -856,6 +856,26 @@ def run_web_report(self, node_id: str) -> Response:
     ...
 ```
 
+**Deprecating a method in favour of the standard API:**
+
+Use the `@deprecated_method` decorator (from `python_sbb_polarion.core.annotations`) for extension methods that duplicate a `PolarionApiV1` operation. It emits a `DeprecationWarning` (pointing at the caller) and records `__deprecated_replacement__` for tooling, while preserving the method signature and any `@restapi_endpoint` metadata via `functools.wraps`. Apply it as the innermost decorator (closest to `def`), below `@restapi_endpoint`:
+
+```python
+from python_sbb_polarion.core.annotations import deprecated_method, restapi_endpoint
+
+@restapi_endpoint(method="GET", path="/api/projects/{id}", path_params={"id": "project_id"}, required_params=["id"])
+@deprecated_method("PolarionApiV1.get_project")
+def get_project(self, project_id: str) -> Response:
+    """Get project info
+
+    .. deprecated::
+        Use ``PolarionApiV1.get_project`` instead.
+    """
+    ...
+```
+
+The `admin-utility` client (`PolarionAdminUtilityApi`) deprecates 16 methods this way (project/collection/document/custom-field/live-report duplicates) — see the migration table in `README.md`. When a convenience method delegates to deprecated public methods, suppress the inner warning with `warnings.catch_warnings()` so callers see exactly one warning (see `set_custom_field_type`).
+
 ### Extensions Module (`python_sbb_polarion/extensions/`)
 Client interfaces for SBB Polarion extensions. Each module corresponds to a specific extension from:
 `https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.*`

--- a/README.md
+++ b/README.md
@@ -56,6 +56,35 @@ result = pdf_api.convert({"projectId": "PROJECT", "documentName": "doc"})
 
 **Current version:** Polarion 2606
 
+### Deprecated `admin-utility` methods
+
+Since Polarion 2606 the standard REST API v1 (`PolarionApiV1`) covers operations that the
+`admin-utility` extension client (`PolarionAdminUtilityApi`) used to re-implement. These duplicates
+are **deprecated** (they emit a `DeprecationWarning`) and will be removed in the next major release.
+Prefer the standard `PolarionApiV1` method:
+
+| `PolarionAdminUtilityApi` (deprecated) | Use `PolarionApiV1` instead |
+|----------------------------------------|-----------------------------|
+| `get_project` | `get_project` |
+| `create_project` | `create_project` (standard endpoint needs an explicit `location`) |
+| `delete_project` | `delete_project` |
+| `create_test_run_template` | `create_testruns` (`isTemplate: true`) |
+| `create_collection` | `create_collections` |
+| `delete_collection` | `delete_collection` |
+| `add_to_collection` | `create_collection_relationships` (relationship `documents`) |
+| `create_document` | `create_documents` |
+| `create_live_report` | `create_page` |
+| `delete_live_report` | `delete_page` |
+| `get_custom_field_declarations` | `get_global_custom_fields` / `get_project_custom_fields` |
+| `declare_custom_field` | `create_global_custom_fields` / `create_project_custom_fields` |
+| `update_custom_fields_for_default_repo` | `update_global_custom_fields` |
+| `update_custom_fields_for_project` | `update_project_custom_field` |
+| `delete_custom_field_declaration` | no direct delete — emulate get + update of the remaining fields |
+| `set_custom_field_type` | `update_project_custom_field` / `update_global_custom_fields` |
+
+Admin-only methods with no standard equivalent are **kept**: tokens, vault records, classic wiki pages,
+trial-license activation, whole-document delete, default-space live reports, and XML configuration endpoints.
+
 ## Documentation
 
 * Internal documentation: See project wiki

--- a/python_sbb_polarion/core/annotations.py
+++ b/python_sbb_polarion/core/annotations.py
@@ -4,12 +4,43 @@ This module provides decorators for explicitly mapping Python methods to REST AP
 enabling precise validation against OpenAPI specifications without relying on method name heuristics.
 """
 
+import functools
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, TypeVar
 
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+def deprecated_method(replacement: str) -> Callable[[F], F]:
+    """Mark a method as deprecated in favour of a standard Polarion REST API v1 method.
+
+    Emits a ``DeprecationWarning`` (pointing at the caller) when the wrapped method is
+    invoked, and records the replacement on the function as ``__deprecated_replacement__``
+    for documentation and tooling. The original signature and any other attributes
+    (e.g. ``__restapi_endpoint__``) are preserved via ``functools.wraps``.
+
+    Args:
+        replacement: Human-readable replacement, e.g. "PolarionApiV1.create_project"
+
+    Returns:
+        Decorator that wraps the method to emit the warning before delegating to it
+    """
+
+    def decorator(func: F) -> F:
+        message: str = f"{func.__qualname__} is deprecated and will be removed in a future major release; use {replacement} instead."
+
+        @functools.wraps(func)
+        def wrapper(*args: object, **kwargs: object) -> object:
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        wrapper.__deprecated_replacement__ = replacement  # type: ignore[attr-defined]
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
 
 
 @dataclass

--- a/python_sbb_polarion/extensions/_admin_utility/_collection.py
+++ b/python_sbb_polarion/extensions/_admin_utility/_collection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from python_sbb_polarion.core.annotations import restapi_endpoint
+from python_sbb_polarion.core.annotations import deprecated_method, restapi_endpoint
 from python_sbb_polarion.extensions._base import BaseMixin
 
 
@@ -26,8 +26,13 @@ class CollectionMixin(BaseMixin):
         },
         required_params=["projectId", "collectionId"],
     )
+    @deprecated_method("PolarionApiV1.delete_collection")
     def delete_collection(self, project_id: str, collection_id: str) -> Response:
         """Delete collection
+
+        .. deprecated::
+            Use ``PolarionApiV1.delete_collection`` instead. The standard Polarion REST API v1
+            covers collection deletion since Polarion 2606.
 
         Returns:
             Response: Response object from the API call
@@ -46,8 +51,13 @@ class CollectionMixin(BaseMixin):
         helper_params=["module_id"],
         required_params=["projectId", "collectionId", "__request_body__"],
     )
+    @deprecated_method("PolarionApiV1.create_collection_relationships")
     def add_to_collection(self, project_id: str, collection_id: str, module_id: str) -> Response:
         """Add an element to the collection
+
+        .. deprecated::
+            Use ``PolarionApiV1.create_collection_relationships`` (relationship ``documents``)
+            instead. Express the module as a JSON:API id (``projectId/spaceId/documentName``).
 
         Returns:
             Response: Response object from the API call
@@ -68,8 +78,13 @@ class CollectionMixin(BaseMixin):
         helper_params=["collection_name"],
         required_params=["projectId", "__request_body__"],
     )
+    @deprecated_method("PolarionApiV1.create_collections")
     def create_collection(self, project_id: str, collection_name: str) -> Response:
         """Create collection
+
+        .. deprecated::
+            Use ``PolarionApiV1.create_collections`` instead. The standard Polarion REST API v1
+            covers collection creation since Polarion 2606.
 
         Returns:
             Response: Response object from the API call

--- a/python_sbb_polarion/extensions/_admin_utility/_custom_fields.py
+++ b/python_sbb_polarion/extensions/_admin_utility/_custom_fields.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
 
 from python_sbb_polarion.core.annotations import deprecated_method, restapi_endpoint
@@ -174,10 +173,11 @@ class CustomFieldsMixin(BaseMixin):
                 },
             ],
         }
-        # The delegated methods are themselves deprecated; suppress their warning so callers of this
-        # convenience method see exactly one DeprecationWarning (the one for set_custom_field_type).
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            if project_id:
-                return self.update_custom_fields_for_project(project_id, data)
-            return self.update_custom_fields_for_default_repo(data)
+        # Issue the request directly rather than delegating to the (also deprecated) update methods:
+        # that keeps this to a single DeprecationWarning without the thread-unsafe warnings.catch_warnings()
+        # (warnings filter state is global before Python 3.12).
+        if project_id:
+            url: str = f"{self.rest_api_url}/projects/{project_id}/custom-fields"
+        else:
+            url = f"{self.rest_api_url}/custom-fields"
+        return self.polarion_connection.api_request_put(url, data=data)

--- a/python_sbb_polarion/extensions/_admin_utility/_custom_fields.py
+++ b/python_sbb_polarion/extensions/_admin_utility/_custom_fields.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
-from python_sbb_polarion.core.annotations import restapi_endpoint
+from python_sbb_polarion.core.annotations import deprecated_method, restapi_endpoint
 from python_sbb_polarion.extensions._base import BaseMixin
 
 
@@ -23,8 +24,13 @@ class CustomFieldsMixin(BaseMixin):
         body_param="data",
         required_params=["__request_body__"],
     )
+    @deprecated_method("PolarionApiV1.update_global_custom_fields")
     def update_custom_fields_for_default_repo(self, data: JsonDict) -> Response:
         """Update custom fields for default repository
+
+        .. deprecated::
+            Use ``PolarionApiV1.update_global_custom_fields`` instead. The standard Polarion REST
+            API v1 covers global custom field updates since Polarion 2606.
 
         Returns:
             Response: Response object from the API call
@@ -41,8 +47,13 @@ class CustomFieldsMixin(BaseMixin):
         body_param="data",
         required_params=["projectId", "__request_body__"],
     )
+    @deprecated_method("PolarionApiV1.update_project_custom_field")
     def update_custom_fields_for_project(self, project_id: str, data: JsonDict) -> Response:
         """Update custom fields for project
+
+        .. deprecated::
+            Use ``PolarionApiV1.update_project_custom_field`` instead. The standard Polarion REST
+            API v1 covers project custom field updates since Polarion 2606.
 
         Returns:
             Response: Response object from the API call
@@ -62,8 +73,13 @@ class CustomFieldsMixin(BaseMixin):
         },
         required_params=["entityType", "typeId"],
     )
+    @deprecated_method("PolarionApiV1.get_global_custom_fields / PolarionApiV1.get_project_custom_fields")
     def get_custom_field_declarations(self, entity_type: str, type_id: str, project_id: str | None = None) -> Response:
         """Get field declarations
+
+        .. deprecated::
+            Use ``PolarionApiV1.get_global_custom_fields`` (or ``get_project_custom_fields`` when a
+            project is given) instead. Covered by the standard Polarion REST API v1 since Polarion 2606.
 
         Returns:
             Response: Response object from the API call
@@ -87,8 +103,13 @@ class CustomFieldsMixin(BaseMixin):
         body_param="data",
         required_params=["entityType", "typeId"],
     )
+    @deprecated_method("PolarionApiV1.create_global_custom_fields / PolarionApiV1.create_project_custom_fields")
     def declare_custom_field(self, entity_type: str, type_id: str, data: JsonDict, project_id: str | None = None) -> Response:
         """Declare a custom field
+
+        .. deprecated::
+            Use ``PolarionApiV1.create_global_custom_fields`` (or ``create_project_custom_fields`` when a
+            project is given) instead. Covered by the standard Polarion REST API v1 since Polarion 2606.
 
         Returns:
             Response: Response object from the API call
@@ -112,8 +133,14 @@ class CustomFieldsMixin(BaseMixin):
         },
         required_params=["entityType", "typeId", "fieldId"],
     )
+    @deprecated_method("PolarionApiV1 custom fields API (emulate get + update of the remaining fields)")
     def delete_custom_field_declaration(self, entity_type: str, type_id: str, field_id: str, project_id: str | None = None) -> Response:
         """Delete a field declaration
+
+        .. deprecated::
+            Use the standard Polarion REST API v1 custom fields API instead. There is no direct
+            per-field delete: the standard ``DELETE`` drops the whole target config, so emulate a
+            single-field delete by reading the declarations and updating with the remaining fields.
 
         Returns:
             Response: Response object from the API call
@@ -124,8 +151,13 @@ class CustomFieldsMixin(BaseMixin):
             params["projectId"] = project_id
         return self.polarion_connection.api_request_delete(url, params=params or None)
 
+    @deprecated_method("PolarionApiV1.update_project_custom_field / PolarionApiV1.update_global_custom_fields")
     def set_custom_field_type(self, field_id: str, field_name: str, field_type: str, field_description: str | None = None, is_required: bool = False, project_id: str | None = None, work_item_type: str | None = None) -> Response:
         """Create or update custom field type (convenience method)
+
+        .. deprecated::
+            Use ``PolarionApiV1.update_project_custom_field`` (or ``update_global_custom_fields`` for the
+            default repository) instead. Covered by the standard Polarion REST API v1 since Polarion 2606.
 
         Returns:
             Response: Response object from the API call
@@ -142,6 +174,10 @@ class CustomFieldsMixin(BaseMixin):
                 },
             ],
         }
-        if project_id:
-            return self.update_custom_fields_for_project(project_id, data)
-        return self.update_custom_fields_for_default_repo(data)
+        # The delegated methods are themselves deprecated; suppress their warning so callers of this
+        # convenience method see exactly one DeprecationWarning (the one for set_custom_field_type).
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            if project_id:
+                return self.update_custom_fields_for_project(project_id, data)
+            return self.update_custom_fields_for_default_repo(data)

--- a/python_sbb_polarion/extensions/_admin_utility/_document.py
+++ b/python_sbb_polarion/extensions/_admin_utility/_document.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from python_sbb_polarion.core.annotations import restapi_endpoint
+from python_sbb_polarion.core.annotations import deprecated_method, restapi_endpoint
 from python_sbb_polarion.extensions._base import BaseMixin
 from python_sbb_polarion.types import Header
 
@@ -30,8 +30,14 @@ class DocumentMixin(BaseMixin):
         },
         required_params=["projectId", "spaceId", "documentName"],
     )
+    @deprecated_method("PolarionApiV1.create_documents")
     def create_document(self, project_id: str, space_id: str, document_name: str, content_type: str, payload: str | bytes) -> Response:
         """Create module
+
+        .. deprecated::
+            Use ``PolarionApiV1.create_documents`` instead. The standard Polarion REST API v1
+            covers document creation since Polarion 2606 (note: it expects JSON:API document
+            type/structure, whereas this method takes a raw body).
 
         Returns:
             Response: Response object from the API call

--- a/python_sbb_polarion/extensions/_admin_utility/_live_report.py
+++ b/python_sbb_polarion/extensions/_admin_utility/_live_report.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from python_sbb_polarion.core.annotations import restapi_endpoint
+from python_sbb_polarion.core.annotations import deprecated_method, restapi_endpoint
 from python_sbb_polarion.extensions._base import BaseMixin
 from python_sbb_polarion.types import Header
 
@@ -30,8 +30,13 @@ class LiveReportMixin(BaseMixin):
         },
         required_params=["projectId", "spaceId", "name"],
     )
+    @deprecated_method("PolarionApiV1.create_page")
     def create_live_report(self, project_id: str, space_id: str, name: str, content_type: str, content: str) -> Response:
         """Create new live report in project
+
+        .. deprecated::
+            Use ``PolarionApiV1.create_page`` instead. In the standard Polarion REST API v1 a
+            rich/live-report page is a ``pages`` resource (project + space scoped) since Polarion 2606.
 
         Returns:
             Response: Response object from the API call
@@ -52,8 +57,13 @@ class LiveReportMixin(BaseMixin):
         },
         required_params=["projectId", "spaceId", "name"],
     )
+    @deprecated_method("PolarionApiV1.delete_page")
     def delete_live_report(self, project_id: str, space_id: str, name: str) -> Response:
         """Delete live report in project
+
+        .. deprecated::
+            Use ``PolarionApiV1.delete_page`` instead. In the standard Polarion REST API v1 a
+            rich/live-report page is a ``pages`` resource (project + space scoped) since Polarion 2606.
 
         Returns:
             Response: Response object from the API call

--- a/python_sbb_polarion/extensions/_admin_utility/_project.py
+++ b/python_sbb_polarion/extensions/_admin_utility/_project.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from python_sbb_polarion.core.annotations import restapi_endpoint
+from python_sbb_polarion.core.annotations import deprecated_method, restapi_endpoint
 from python_sbb_polarion.extensions._base import BaseMixin
 
 
@@ -24,8 +24,14 @@ class ProjectMixin(BaseMixin):
         helper_params=["project_id", "project_name", "template_id"],
         required_params=["__request_body__"],
     )
+    @deprecated_method("PolarionApiV1.create_project")
     def create_project(self, project_id: str, project_name: str, template_id: str) -> Response:
         """Create project from specified project template
+
+        .. deprecated::
+            Use ``PolarionApiV1.create_project`` instead. The standard Polarion REST API v1
+            (``POST /projects/actions/createProject``) covers project creation since Polarion 2606.
+            Note: the standard endpoint requires an explicit ``location`` (this method hardcoded it).
 
         Returns:
             Response: Response object from the API call
@@ -48,8 +54,14 @@ class ProjectMixin(BaseMixin):
         helper_params=["template_id"],
         required_params=["projectId"],
     )
+    @deprecated_method("PolarionApiV1.create_testruns")
     def create_test_run_template(self, project_id: str, template_id: str) -> Response:
         """Create test run template
+
+        .. deprecated::
+            Use ``PolarionApiV1.create_testruns`` with ``isTemplate: true`` instead.
+            The standard Polarion REST API v1 creates a test run template via
+            ``POST /projects/{projectId}/testruns``.
 
         Returns:
             Response: Response object from the API call
@@ -68,8 +80,13 @@ class ProjectMixin(BaseMixin):
         },
         required_params=["id"],
     )
+    @deprecated_method("PolarionApiV1.get_project")
     def get_project(self, project_id: str) -> Response:
         """Get project info
+
+        .. deprecated::
+            Use ``PolarionApiV1.get_project`` instead. The standard Polarion REST API v1
+            (``GET /projects/{projectId}``) covers reading a project since Polarion 2606.
 
         Returns:
             Response: Response object from the API call
@@ -85,8 +102,13 @@ class ProjectMixin(BaseMixin):
         },
         required_params=["id"],
     )
+    @deprecated_method("PolarionApiV1.delete_project")
     def delete_project(self, project_id: str) -> Response:
         """Delete project info
+
+        .. deprecated::
+            Use ``PolarionApiV1.delete_project`` instead. The standard Polarion REST API v1
+            (``DELETE /projects/{projectId}``) covers project deletion since Polarion 2606.
 
         Returns:
             Response: Response object from the API call

--- a/tests/unit/core/test_annotations.py
+++ b/tests/unit/core/test_annotations.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import unittest
+import warnings
 from typing import TYPE_CHECKING, cast
 
-from python_sbb_polarion.core.annotations import RestApiEndpoint, restapi_endpoint
+from python_sbb_polarion.core.annotations import RestApiEndpoint, deprecated_method, restapi_endpoint
 
 
 if TYPE_CHECKING:
@@ -259,6 +260,51 @@ class TestRestApiEndpointDecorator(unittest.TestCase):
 
         # Function should have metadata attached
         self.assertTrue(hasattr(sample_function, "__restapi_endpoint__"))
+
+
+class TestDeprecatedMethod(unittest.TestCase):
+    """Test the deprecated_method decorator."""
+
+    def test_emits_deprecation_warning_and_preserves_return(self) -> None:
+        """Test the wrapped method warns and still returns the original result."""
+
+        @deprecated_method("PolarionApiV1.do_thing")
+        def sample(value: int) -> int:
+            return value * 2
+
+        with self.assertWarns(DeprecationWarning) as ctx:
+            result: int = sample(5)
+
+        self.assertEqual(result, 10)
+        self.assertIn("PolarionApiV1.do_thing", str(ctx.warning))
+        self.assertIn("sample", str(ctx.warning))
+
+    def test_records_replacement_and_preserves_metadata(self) -> None:
+        """Test the decorator records the replacement and preserves name/signature/annotations."""
+
+        @restapi_endpoint(method="GET", path="/api/test")
+        @deprecated_method("PolarionApiV1.do_thing")
+        def sample(value: int) -> int:
+            return value
+
+        self.assertEqual(sample.__deprecated_replacement__, "PolarionApiV1.do_thing")  # type: ignore[attr-defined]
+        self.assertEqual(sample.__name__, "sample")
+        # restapi_endpoint metadata applied on top of the deprecation wrapper is still reachable
+        self.assertTrue(hasattr(sample, "__restapi_endpoint__"))
+
+    def test_warning_points_at_caller(self) -> None:
+        """Test stacklevel=2 attributes the warning to the caller, not the wrapper."""
+
+        @deprecated_method("PolarionApiV1.do_thing")
+        def sample() -> None:
+            return None
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            sample()
+
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(caught[0].filename, __file__)
 
 
 if __name__ == "__main__":

--- a/tests/unit/extensions/test_admin_utility.py
+++ b/tests/unit/extensions/test_admin_utility.py
@@ -604,7 +604,7 @@ class TestAdminUtilityDeprecation(unittest.TestCase):
         self.assertIn("PolarionApiV1.create_project", str(ctx.warning))
 
     def test_set_custom_field_type_emits_single_warning(self) -> None:
-        """Test the convenience method emits exactly one warning (delegated calls are suppressed)."""
+        """Test the convenience method emits exactly one warning (it issues the request directly)."""
         api: PolarionAdminUtilityApi = PolarionAdminUtilityApi(Mock())
 
         with warnings.catch_warnings(record=True) as caught:

--- a/tests/unit/extensions/test_admin_utility.py
+++ b/tests/unit/extensions/test_admin_utility.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import unittest
-from typing import TYPE_CHECKING
+import warnings
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from unittest.mock import Mock
 
 from python_sbb_polarion.extensions.admin_utility import PolarionAdminUtilityApi
@@ -528,3 +529,88 @@ class TestPolarionAdminUtilityApi(unittest.TestCase):
         self.mock_connection.api_request_delete.assert_called_once_with(
             f"{self.api.rest_api_url}/vault/my-key",
         )
+
+
+# Methods deprecated in favour of PolarionApiV1 (issue #62), with their expected replacement marker.
+DEPRECATED_METHODS: dict[str, str] = {
+    "get_project": "PolarionApiV1.get_project",
+    "create_project": "PolarionApiV1.create_project",
+    "delete_project": "PolarionApiV1.delete_project",
+    "create_test_run_template": "PolarionApiV1.create_testruns",
+    "create_collection": "PolarionApiV1.create_collections",
+    "delete_collection": "PolarionApiV1.delete_collection",
+    "add_to_collection": "PolarionApiV1.create_collection_relationships",
+    "create_document": "PolarionApiV1.create_documents",
+    "create_live_report": "PolarionApiV1.create_page",
+    "delete_live_report": "PolarionApiV1.delete_page",
+    "get_custom_field_declarations": "PolarionApiV1.get_global_custom_fields / PolarionApiV1.get_project_custom_fields",
+    "declare_custom_field": "PolarionApiV1.create_global_custom_fields / PolarionApiV1.create_project_custom_fields",
+    "update_custom_fields_for_default_repo": "PolarionApiV1.update_global_custom_fields",
+    "update_custom_fields_for_project": "PolarionApiV1.update_project_custom_field",
+    "delete_custom_field_declaration": "PolarionApiV1 custom fields API (emulate get + update of the remaining fields)",
+    "set_custom_field_type": "PolarionApiV1.update_project_custom_field / PolarionApiV1.update_global_custom_fields",
+}
+
+# Admin-only methods that must NOT be deprecated (no standard equivalent).
+KEEP_METHODS: list[str] = [
+    "create_token",
+    "delete_token",
+    "delete_all_tokens",
+    "create_vault_record",
+    "get_vault_record",
+    "delete_vault_record",
+    "create_wiki_page",
+    "delete_wiki_page",
+    "activate_trial_license",
+    "delete_document",
+    "create_live_report_in_default_space",
+    "delete_live_report_in_default_space",
+    "get_document_types_configuration",
+]
+
+
+@runtime_checkable
+class _DeprecatedMethod(Protocol):
+    """Structural type for methods carrying the deprecation marker."""
+
+    __deprecated_replacement__: str
+
+
+class TestAdminUtilityDeprecation(unittest.TestCase):
+    """Test deprecation markers on methods covered by PolarionApiV1 (issue #62)."""
+
+    def test_all_expected_methods_are_marked_deprecated(self) -> None:
+        """Test each confirmed duplicate carries the __deprecated_replacement__ marker."""
+        for name, replacement in DEPRECATED_METHODS.items():
+            method: object = getattr(PolarionAdminUtilityApi, name)
+            if isinstance(method, _DeprecatedMethod):
+                self.assertEqual(method.__deprecated_replacement__, replacement)
+            else:
+                self.fail(f"{name} is expected to be deprecated but has no marker")
+
+    def test_kept_methods_are_not_deprecated(self) -> None:
+        """Test admin-only methods (no standard equivalent) are NOT deprecated."""
+        for name in KEEP_METHODS:
+            method: object = getattr(PolarionAdminUtilityApi, name)
+            self.assertNotIsInstance(method, _DeprecatedMethod, f"{name} must not be deprecated (no standard equivalent)")
+
+    def test_calling_deprecated_method_emits_warning(self) -> None:
+        """Test a representative deprecated method emits a DeprecationWarning when called."""
+        api: PolarionAdminUtilityApi = PolarionAdminUtilityApi(Mock())
+
+        with self.assertWarns(DeprecationWarning) as ctx:
+            api.create_project("PROJ", "Project", "template")
+
+        self.assertIn("PolarionApiV1.create_project", str(ctx.warning))
+
+    def test_set_custom_field_type_emits_single_warning(self) -> None:
+        """Test the convenience method emits exactly one warning (delegated calls are suppressed)."""
+        api: PolarionAdminUtilityApi = PolarionAdminUtilityApi(Mock())
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            api.set_custom_field_type("field1", "Field 1", "string", project_id="PROJ")
+
+        deprecation_warnings: list[warnings.WarningMessage] = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(deprecation_warnings), 1)
+        self.assertIn("set_custom_field_type", str(deprecation_warnings[0].message))


### PR DESCRIPTION
### Proposed changes

Mark multiple methods in the admin utility as deprecated, directing users to the corresponding standard Polarion REST API v1 methods. This change ensures a smoother transition to the updated API and reduces redundancy.

- Added @deprecated_method decorator to 16 methods
- Updated documentation to reflect deprecations and replacements

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
