### PR TITLE
feat: support nesting temp projects under a project group via parent_location

### DIFF
--- a/python_sbb_polarion/polarion_project_manager/project_manager.py
+++ b/python_sbb_polarion/polarion_project_manager/project_manager.py
@@ -103,6 +103,7 @@ class PolarionProjectManager:
         template_id: str = "custom_project_template_for_st",
         project_id: str = "elibrary",
         project_name: str = "E-Library",
+        parent_location: str | None = None,
     ) -> TempProject:
         """
         Create a temporary Polarion project from a template.
@@ -112,6 +113,8 @@ class PolarionProjectManager:
             project_id: ID for the temporary project.
             project_name: Display name for the temporary project.
             template_id: Template identifier.
+            parent_location: Repository folder (project group) to create the project under; the
+                project id is appended to it. When omitted the project is created at the root.
 
         Returns:
             TempProject instance.
@@ -136,6 +139,7 @@ class PolarionProjectManager:
                 project_name=project_name,
                 template_id=template_id,
                 template_location=template_file,
+                parent_location=parent_location,
             )
         except Exception:
             logger.exception("Failed to create project from template '%s'", template_path)

--- a/python_sbb_polarion/testing/temp_project.py
+++ b/python_sbb_polarion/testing/temp_project.py
@@ -82,10 +82,13 @@ class TempProject:
         self.temp_project_template_id: str = template_id
         self.temp_project_template_location: Path | None = template_location
         # A project's project-group membership is derived from its location in the repository tree.
-        # Nest the project under parent_location when given (so group-scoped behaviour applies), else
-        # keep it at the root using the bare project id.
-        if parent_location:
-            self.temp_project_location: str = f"{parent_location.rstrip('/')}/{self.temp_project_id}"
+        # Nest the project under parent_location when a non-blank value is given (so group-scoped
+        # behaviour applies); a missing, empty or whitespace-only value intentionally keeps the
+        # project at the root using the bare project id. Surrounding whitespace and trailing
+        # slashes are stripped so the resulting location never contains a doubled separator.
+        normalized_parent: str = (parent_location or "").strip().rstrip("/")
+        if normalized_parent:
+            self.temp_project_location: str = f"{normalized_parent}/{self.temp_project_id}"
         else:
             self.temp_project_location = self.temp_project_id
 
@@ -114,7 +117,7 @@ class TempProject:
         # A 404 here just means the project does not exist yet, so suppress the client's non-2xx warning.
         existing_response: Response = self.polarion_api.get_project(self.temp_project_id, print_error=False)
         if existing_response.status_code == HTTPStatus.OK:
-            logger.info("'%s' already exists... nothing to do", self.temp_project_id)
+            logger.info("'%s' already exists... nothing to do", self.temp_project_location)
             return
         # Anything other than "exists" (200) or "not found" (404) is an obstacle (auth, server error)
         # that creation would not solve - surface it here with the real status instead of falling through.
@@ -160,19 +163,19 @@ class TempProject:
             },
         }
         response: Response = self.polarion_api.update_project(self.temp_project_id, data)
-        if response.status_code not in {HTTPStatus.OK, HTTPStatus.NO_CONTENT}:
+        if response.status_code != HTTPStatus.NO_CONTENT:
             logger.warning(
                 "Could not set name for project '%s' (status %s)",
-                self.temp_project_id,
+                self.temp_project_location,
                 response.status_code,
             )
 
     def _fail(self, action: str, response: Response) -> NoReturn:
-        logger.error("Error during %s project '%s'", action, self.temp_project_id)
+        logger.error("Error during %s project '%s'", action, self.temp_project_location)
         logger.debug("Response status: %s", response.status_code)
         logger.debug("Response headers: %s", response.headers)
         logger.debug("Response content: %s", response.content)
-        raise TempProjectError(f"Failed to {action} project '{self.temp_project_id}' (HTTP {response.status_code})")
+        raise TempProjectError(f"Failed to {action} project '{self.temp_project_location}' (HTTP {response.status_code})")
 
     def _wait_for_job(self, response: Response, action: str) -> None:
         """Poll the job referenced by an async 202 response until it reaches a terminal status.
@@ -204,11 +207,11 @@ class TempProject:
             if status_type == JOB_STATUS_OK:
                 return
             if status_type in JOB_STATUS_FAILURES:
-                raise TempProjectError(f"Job to {action} project '{self.temp_project_id}' ended as {status_type}: {message}")
+                raise TempProjectError(f"Job to {action} project '{self.temp_project_location}' ended as {status_type}: {message}")
             if attempt < POLL_MAX_ATTEMPTS - 1:
                 time.sleep(POLL_INTERVAL_SECONDS)
 
-        raise TempProjectError(f"Timed out waiting for {action} job '{job_id}' of project '{self.temp_project_id}'")
+        raise TempProjectError(f"Timed out waiting for {action} job '{job_id}' of project '{self.temp_project_location}'")
 
     @staticmethod
     def _safe_json(response: Response) -> JsonDict:
@@ -241,8 +244,8 @@ class TempProject:
             job_id: JsonValue = data.get("id")
             if isinstance(job_id, str) and job_id:
                 return job_id
-        logger.error("Unexpected async %s response for project '%s': %s", action, self.temp_project_id, body)
-        raise TempProjectError(f"Async {action} response for project '{self.temp_project_id}' carried no job id")
+        logger.error("Unexpected async %s response for project '%s': %s", action, self.temp_project_location, body)
+        raise TempProjectError(f"Async {action} response for project '{self.temp_project_location}' carried no job id")
 
     @staticmethod
     def _job_status(job_body: JsonDict) -> tuple[str | None, str | None]:

--- a/python_sbb_polarion/testing/temp_project.py
+++ b/python_sbb_polarion/testing/temp_project.py
@@ -55,6 +55,11 @@ class TempProject:
             )
         mutate_project_id: Whether to append a UUID suffix to project_id for uniqueness
         transform_links: mapping to transform links during template upload, e.g. {"old_project_id": "new_project_id"}
+        parent_location: Repository folder (project group) to create the project under. The project id
+            is appended to it, so e.g. parent_location="Demo Projects" places the project at
+            "Demo Projects/<project_id>" and thus inside the "Demo Projects" project group. When omitted
+            the project is created at the repository root (location == project id), preserving the
+            previous default behaviour.
     """
 
     def __init__(
@@ -65,6 +70,7 @@ class TempProject:
         template_location: Path | None = None,
         mutate_project_id: bool = True,
         transform_links: SparseFields | None = None,
+        parent_location: str | None = None,
     ) -> None:
         logging.basicConfig(level=logging.INFO, format="%(message)s")
 
@@ -75,6 +81,13 @@ class TempProject:
         self.temp_project_name: str = project_name
         self.temp_project_template_id: str = template_id
         self.temp_project_template_location: Path | None = template_location
+        # A project's project-group membership is derived from its location in the repository tree.
+        # Nest the project under parent_location when given (so group-scoped behaviour applies), else
+        # keep it at the root using the bare project id.
+        if parent_location:
+            self.temp_project_location: str = f"{parent_location.rstrip('/')}/{self.temp_project_id}"
+        else:
+            self.temp_project_location = self.temp_project_id
 
         # Build the API clients once up front, sharing a single connection: the test-data extension
         # client is derived from the standard API's connection instead of opening a second one.
@@ -114,7 +127,7 @@ class TempProject:
         data: JsonDict = {
             "projectId": self.temp_project_id,
             "trackerPrefix": self.temp_project_id,
-            "location": self.temp_project_id,
+            "location": self.temp_project_location,
             "templateId": self.temp_project_template_id,
         }
         response: Response = self.polarion_api.create_project(data)
@@ -129,7 +142,7 @@ class TempProject:
 
         logger.info(
             "'%s' have been created in %.2f seconds",
-            self.temp_project_id,
+            self.temp_project_location,
             time.time() - start_time,
         )
 
@@ -172,7 +185,7 @@ class TempProject:
             TempProjectError: If the job fails, is cancelled, or never reaches a terminal status
         """
         job_id: str = self._job_id_from_response(response, action)
-        logger.info("Waiting for %s job '%s' of project '%s'...", action, job_id, self.temp_project_id)
+        logger.info("Waiting for %s job '%s' of project '%s'...", action, job_id, self.temp_project_location)
 
         for attempt in range(POLL_MAX_ATTEMPTS):
             job_response: Response = self.polarion_api.get_job(job_id)
@@ -275,4 +288,4 @@ class TempProject:
 
         self._wait_for_job(response, "deletion")
 
-        logger.info("'%s' have been deleted in %.2f seconds", self.temp_project_id, time.time() - start_time)
+        logger.info("'%s' have been deleted in %.2f seconds", self.temp_project_location, time.time() - start_time)

--- a/tests/unit/polarion_project_manager/test_polarion_project_manager.py
+++ b/tests/unit/polarion_project_manager/test_polarion_project_manager.py
@@ -145,7 +145,7 @@ class TestPolarionProjectManager(unittest.TestCase):
         result: TempProject = PolarionProjectManager.create_project(template_path=str(template_path), template_id="test_template", project_id="test_proj", project_name="Test Project")
 
         self.assertEqual(result.temp_project_id, "temp_test_project")
-        mock_temp_project.assert_called_once_with(project_id="test_proj", project_name="Test Project", template_id="test_template", template_location=template_path)
+        mock_temp_project.assert_called_once_with(project_id="test_proj", project_name="Test Project", template_id="test_template", template_location=template_path, parent_location=None)
 
     def test_create_project_file_not_found(self) -> None:
         """Test error when template file doesn't exist."""

--- a/tests/unit/testing/test_temp_project.py
+++ b/tests/unit/testing/test_temp_project.py
@@ -135,6 +135,22 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    def test_init_treats_blank_parent_location_as_root(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
+        """Test an empty or whitespace-only parent_location is treated as root, not a doubled separator."""
+        # Arrange
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="uuid-suffix")
+        mock_create_api.return_value = _success_polarion_api()
+
+        # Act - whitespace-only parent must collapse to the bare project id (root)
+        temp_project = TempProject("PROJ", "Project Name", "template", parent_location="   ")
+
+        # Assert
+        self.assertEqual(temp_project.temp_project_location, "PROJ_st_suffix")
+
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     def test_get_temp_project_id(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test get_temp_project_id returns project ID."""
         # Arrange

--- a/tests/unit/testing/test_temp_project.py
+++ b/tests/unit/testing/test_temp_project.py
@@ -94,6 +94,47 @@ class TestTempProject(unittest.TestCase):
     @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
     @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
     @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    def test_init_nests_project_under_parent_location(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
+        """Test parent_location nests the project under the given group folder (appending the project id)."""
+        # Arrange
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="uuid-suffix")
+        mock_api: Mock = _success_polarion_api()
+        mock_create_api.return_value = mock_api
+
+        # Act - a trailing slash on the parent must not produce a doubled separator
+        temp_project = TempProject("PROJ", "Project Name", "template", parent_location="Demo Projects/")
+
+        # Assert
+        self.assertEqual(temp_project.temp_project_location, "Demo Projects/PROJ_st_suffix")
+        mock_api.create_project.assert_called_once_with(
+            {
+                "projectId": "PROJ_st_suffix",
+                "trackerPrefix": "PROJ_st_suffix",
+                "location": "Demo Projects/PROJ_st_suffix",
+                "templateId": "template",
+            }
+        )
+
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
+    def test_init_defaults_location_to_project_id(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
+        """Test that without parent_location the project location stays the bare project id (root)."""
+        # Arrange
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="uuid-suffix")
+        mock_create_api.return_value = _success_polarion_api()
+
+        # Act
+        temp_project = TempProject("PROJ", "Project Name", "template")
+
+        # Assert
+        self.assertEqual(temp_project.temp_project_location, "PROJ_st_suffix")
+
+    @patch("python_sbb_polarion.testing.temp_project.ExtensionApiFactory.get_extension_api_by_name")
+    @patch("python_sbb_polarion.testing.temp_project.GenericTestCase.create_polarion_api")
+    @patch("python_sbb_polarion.testing.temp_project.uuid.uuid4")
     def test_get_temp_project_id(self, mock_uuid: Mock, mock_create_api: Mock, mock_factory: Mock) -> None:
         """Test get_temp_project_id returns project ID."""
         # Arrange

--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ wheels = [
 
 [[package]]
 name = "python-sbb-polarion"
-version = "2.1.1"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
### Proposed changes

This pull request adds support for specifying a parent folder (project group) when creating a temporary Polarion project, allowing projects to be created under a specific group in the repository tree rather than always at the root. The changes update both the implementation and the documentation, and introduce new tests to ensure correct behavior.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
